### PR TITLE
log the errors always

### DIFF
--- a/mediapipe/framework/calculator_graph.cc
+++ b/mediapipe/framework/calculator_graph.cc
@@ -934,10 +934,10 @@ void CalculatorGraph::RecordError(const ::mediapipe::Status& error) {
     for (const auto& stream : graph_output_streams_) {
       stream->NotifyError();
     }
+    for (const ::mediapipe::Status& error : errors_) {
+      LOG(ERROR) << error;
+    }
     if (errors_.size() > kMaxNumAccumulatedErrors) {
-      for (const ::mediapipe::Status& error : errors_) {
-        LOG(ERROR) << error;
-      }
       LOG(FATAL) << "Forcefully aborting to prevent the framework running out "
                     "of memory.";
     }


### PR DESCRIPTION
> constexpr int kMaxNumAccumulatedErrors = 1000;

only the errors count is large than 1000, the errors can be printed.

I think error log is very important to developers. It should be printed when it happened.