### PR TITLE
enable NNAPI in CPU path

### DIFF
--- a/mediapipe/calculators/tflite/tflite_inference_calculator.cc
+++ b/mediapipe/calculators/tflite/tflite_inference_calculator.cc
@@ -305,6 +305,10 @@ REGISTER_CALCULATOR(TfLiteInferenceCalculator);
 #endif
   } else {
     // Read CPU input into tensors.
+    interpreter_->SetAllowFp16PrecisionForFp32(1);
+    delegate_ = tflite::NnApiDelegate();
+    interpreter_->ModifyGraphWithDelegate(delegate_);
+
     const auto& input_tensors =
         cc->Inputs().Tag("TENSORS").Get<std::vector<TfLiteTensor>>();
     RET_CHECK_GT(input_tensors.size(), 0);


### PR DESCRIPTION
With NNAPI delegate added, Android devices with floating point
NNAPI device(s) could run facedectioncpu and objectdectioncpu
accelerated. On devices without accelerators, tflite interpreter
will simply fall back to CPU.