### PR TITLE
Added assets and assets_dir.

### DIFF
--- a/mediapipe/java/com/google/mediapipe/mediapipe_aar.bzl
+++ b/mediapipe/java/com/google/mediapipe/mediapipe_aar.bzl
@@ -26,12 +26,16 @@ Finally, import the AAR into Android Studio.
 
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary", "android_library")
 
-def mediapipe_aar(name, calculators = []):
+def mediapipe_aar(name, calculators = [], assets = [], assets_dir = ""):
     """Generate MediaPipe AAR.
 
     Args:
       name: the name of the AAR.
       calculators: the calculator libraries to be compiled into the .so.
+      assets: additional assets to be included into the archive.
+      assets_dir: path where the assets will the packaged. See
+                  https://docs.bazel.build/versions/master/be/android.html#android_library 
+                  for more information.
     """
     native.cc_binary(
         name = "libmediapipe_jni.so",
@@ -106,6 +110,8 @@ cat > $(OUTS) <<EOF
             "@com_google_guava_android//jar",
             "@androidx_lifecycle//jar",
         ],
+        assets = assets,
+        assets_dir = assets_dir,
     )
 
     _aar_with_jni(name, name + "_android_lib")


### PR DESCRIPTION
Added `assets` and `assets_dir` parameters to `mediapipe_aar` to include compiled protobuf graphs into the generated archive. This allows having a ready-to-go Android Archive with the mediapipe library and graph assets to export to other projects.

Mode of use:

```python
load("//mediapipe/java/com/google/mediapipe:mediapipe_aar.bzl", "mediapipe_aar")
load("//mediapipe/framework/tool:mediapipe_graph.bzl", "mediapipe_binary_graph")

package(default_visibility = ["//visibility:public"])

"""
Consider passthrough.pbtxt as the following:

    input_stream: "input_video"
    output_stream: "output_video"

    node {
      calculator: "PassThroughCalculator"
      input_stream: "input_video"
      output_stream: "output_video"
    }

"""
mediapipe_binary_graph(
    name = "passthrough_binary_graph",
    graph = "passthrough.pbtxt",
    output_name = "passthrough.binarypb",
)

mediapipe_aar(
    name = "mediapipe_aar",
    assets = [
        "//mediapipe/mpgenius/graphs/passthrough:passthrough_binary_graph",
    ],
    # the passthrough.binarypb will be avaiable in assets/passthrough.binarypb
    # inside the Android app.
    assets_dir = "",
    calculators = [
        "//mediapipe/calculators/core:pass_through_calculator",
    ],
)

```