### PR TITLE
In normal case channel order is NHWC

### DIFF
--- a/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto
+++ b/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.proto
@@ -24,8 +24,8 @@ message TfLiteTensorsToSegmentationCalculatorOptions {
   }
 
   // Dimensions of input segmentation tensor to process.
-  required int32 tensor_width = 1;
-  required int32 tensor_height = 2;
+  required int32 tensor_height = 1;
+  required int32 tensor_width = 2;
   required int32 tensor_channels = 3;
 
   // How much to use previous mask when computing current one; range [0-1].


### PR DESCRIPTION
The original setting will result in error when input height != width