### PR TITLE
Fix typo in comment.

### DIFF
--- a/mediapipe/framework/packet.h
+++ b/mediapipe/framework/packet.h
@@ -92,7 +92,7 @@ class Packet {
   // the new Packet with the given timestamp.
   Packet At(class Timestamp timestamp) &&;
 
-  // Returns true iff the Packet has been created using the default
+  // Returns true if the Packet has been created using the default
   // constructor Packet(), or is a copy of such a Packet.
   bool IsEmpty() const;
 


### PR DESCRIPTION
There are many `iff` in comments.
https://github.com/google/mediapipe/search?q=iff

If it is a comment rule, just close it.