### PR TITLE
fix test TryToAddPacketToInputStream

### DIFF
--- a/mediapipe/framework/calculator_graph_event_loop_test.cc
+++ b/mediapipe/framework/calculator_graph_event_loop_test.cc
@@ -375,7 +375,7 @@ TEST_F(CalculatorGraphEventLoopTest, TryToAddPacketToInputStream) {
                         this, std::placeholders::_1))},
        {"blocking_mutex", mutex_side_packet}}));
 
-  constexpr int kNumInputPackets = 2;
+  constexpr int kNumInputPackets = 20;
   constexpr int kMaxQueueSize = 1;
 
   // Lock the mutex so that the BlockingPassThroughCalculator cannot read any of


### PR DESCRIPTION
kNumInputPackets=2, kNumInputPackets - kMaxQueueSize - 1 = 0; fail_count == 0 can also pass this test, which is not desired.