### PR TITLE
fix: build the box tracking example with OpenCV 4

### DIFF
--- a/mediapipe/framework/port/opencv_imgproc_inc.h
+++ b/mediapipe/framework/port/opencv_imgproc_inc.h
@@ -23,6 +23,11 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #else
 #include <opencv2/imgproc.hpp>
+
+#if CV_MAJOR_VERSION == 4
+#include <opencv2/imgproc/types_c.h>
+#endif
+
 #endif
 
 #endif  // MEDIAPIPE_PORT_OPENCV_IMGPROC_INC_H_


### PR DESCRIPTION
fixes #1034 

With OpenCV 4, some constants are missing to build the box tracking example.
This PR only fixes build errors, so the example does not work still.

cf. https://github.com/google/mediapipe/blob/master/mediapipe/util/tracking/region_flow_computation.cc#L2790