### PR TITLE
Bug iris no face detected hangs

### DIFF
--- a/mediapipe/calculators/util/landmark_projection_calculator.cc
+++ b/mediapipe/calculators/util/landmark_projection_calculator.cc
@@ -100,7 +100,7 @@ class LandmarkProjectionCalculator : public CalculatorBase {
 
     CollectionItemId input_id = cc->Inputs().BeginId(kLandmarksTag);
     CollectionItemId output_id = cc->Outputs().BeginId(kLandmarksTag);
-    // Number of inputs and outpus is the same according to the contract.
+    // Number of inputs and outputs is the same according to the contract.
     for (; input_id != cc->Inputs().EndId(kLandmarksTag);
          ++input_id, ++output_id) {
       const auto& input_packet = cc->Inputs().Get(input_id);

--- a/mediapipe/calculators/util/non_max_suppression_calculator.cc
+++ b/mediapipe/calculators/util/non_max_suppression_calculator.cc
@@ -199,6 +199,9 @@ class NonMaxSuppressionCalculator : public CalculatorBase {
       if (options_.return_empty_detections()) {
         cc->Outputs().Index(0).Add(new Detections(), cc->InputTimestamp());
       }
+      if (options_.error_on_empty_detections()) {
+        return ::mediapipe::InternalError("NonMaxSuppression received empty detections, but detections are required for this pipeline.");
+       }
       return ::mediapipe::OkStatus();
     }
 

--- a/mediapipe/calculators/util/non_max_suppression_calculator.proto
+++ b/mediapipe/calculators/util/non_max_suppression_calculator.proto
@@ -58,6 +58,9 @@ message NonMaxSuppressionCalculatorOptions {
   // Whether to put empty detection vector in output stream.
   optional bool return_empty_detections = 5;
 
+  // Whether to throw an error on an empty input detection vector
+  optional bool error_on_empty_detections = 8;
+
   // Algorithms that can be used to apply non-maximum suppression.
   enum NmsAlgorithm {
     DEFAULT = 0;

--- a/mediapipe/modules/face_detection/face_detection_front_cpu.pbtxt
+++ b/mediapipe/modules/face_detection/face_detection_front_cpu.pbtxt
@@ -128,6 +128,7 @@ node {
       min_suppression_threshold: 0.3
       overlap_type: INTERSECTION_OVER_UNION
       algorithm: WEIGHTED
+      error_on_empty_detections: true
     }
   }
 }


### PR DESCRIPTION
I opened an issue: #1033 for a bug I found where the iris depth detection can hang on an individual image. One case this happens is when no faces are detected. My proposed fix is to throw an error when an option is provided that requires the detections vector for non-max suppression not be empty.
