### PR TITLE
fix DetectionUniqueIdCalculator consume prob

### DIFF
--- a/mediapipe/calculators/util/detection_unique_id_calculator.cc
+++ b/mediapipe/calculators/util/detection_unique_id_calculator.cc
@@ -33,8 +33,8 @@ inline int GetNextDetectionId() { return ++detection_id; }
 }  // namespace
 
 // Assign a unique id to detections.
-// Note that the calculator will consume the input vector of Detection or
-// DetectionList. So the input stream can not be connected to other calculators.
+// Note that the calculator will consume or copy the input vector of Detection or
+// DetectionList. 
 //
 // Example config:
 // node {
@@ -76,7 +76,7 @@ REGISTER_CALCULATOR(DetectionUniqueIdCalculator);
   if (cc->Inputs().HasTag(kDetectionListTag) &&
       !cc->Inputs().Tag(kDetectionListTag).IsEmpty()) {
     auto result =
-        cc->Inputs().Tag(kDetectionListTag).Value().Consume<DetectionList>();
+        cc->Inputs().Tag(kDetectionListTag).Value().ConsumeOrCopy<DetectionList>();
     if (result.ok()) {
       auto detection_list = std::move(result).ValueOrDie();
       for (Detection& detection : *detection_list->mutable_detection()) {
@@ -93,7 +93,7 @@ REGISTER_CALCULATOR(DetectionUniqueIdCalculator);
     auto result = cc->Inputs()
                       .Tag(kDetectionsTag)
                       .Value()
-                      .Consume<std::vector<Detection>>();
+                      .ConsumeOrCopy<std::vector<Detection>>();
     if (result.ok()) {
       auto detections = std::move(result).ValueOrDie();
       for (Detection& detection : *detections) {


### PR DESCRIPTION
The subgraph 'ObjectTrackingSubgraphGpu' is useful in many cases. In some cases we need to connect the input stream 'new_detections' for other calculators, but the ‘DetectionUniqueIdCalculator’ can't accept it. I think use 'ConsumeOrCopy' will be better.

![image](https://user-images.githubusercontent.com/6057711/98197324-6a430d00-1f61-11eb-8998-e561848c292a.png)
