### PR TITLE
Make object tracking works on iOS

### DIFF
--- a/mediapipe/examples/ios/common/CommonViewController.h
+++ b/mediapipe/examples/ios/common/CommonViewController.h
@@ -18,6 +18,7 @@
 #import "mediapipe/objc/MPPGraph.h"
 #import "mediapipe/objc/MPPLayerRenderer.h"
 #import "mediapipe/objc/MPPPlayerInputSource.h"
+#import "mediapipe/objc/MPPTimestampConverter.h"
 
 typedef NS_ENUM(NSInteger, MediaPipeDemoSourceMode) {
   MediaPipeDemoSourceCamera,
@@ -59,5 +60,8 @@ typedef NS_ENUM(NSInteger, MediaPipeDemoSourceMode) {
 
 // Graph output stream.
 @property(nonatomic) const char* graphOutputStream;
+
+// Convert video time to mediapipe internal Timestamp
+@property(nonatomic) MPPTimestampConverter* timestampConverter;
 
 @end

--- a/mediapipe/examples/ios/common/CommonViewController.mm
+++ b/mediapipe/examples/ios/common/CommonViewController.mm
@@ -76,6 +76,7 @@ static const char* kVideoQueueLabel = "com.google.mediapipe.example.videoQueue";
   self.renderer.layer.frame = self.liveView.layer.bounds;
   [self.liveView.layer addSublayer:self.renderer.layer];
   self.renderer.frameScaleMode = MPPFrameScaleModeFillAndCrop;
+  self.timestampConverter = [[MPPTimestampConverter alloc] init];
 
   dispatch_queue_attr_t qosAttribute = dispatch_queue_attr_make_with_qos_class(
       DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, /*relative_priority=*/0);
@@ -173,7 +174,8 @@ static const char* kVideoQueueLabel = "com.google.mediapipe.example.videoQueue";
 
   [self.mediapipeGraph sendPixelBuffer:imageBuffer
                             intoStream:self.graphInputStream
-                            packetType:MPPPacketTypePixelBuffer];
+                            packetType:MPPPacketTypePixelBuffer
+                            timestamp:[self.timestampConverter timestampForMediaTime:timestamp]];
 }
 
 #pragma mark - MPPGraphDelegate methods

--- a/mediapipe/examples/ios/objecttrackinggpu/BUILD
+++ b/mediapipe/examples/ios/objecttrackinggpu/BUILD
@@ -1,0 +1,70 @@
+# Copyright 2019 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_application",
+)
+load(
+    "//mediapipe/examples/ios:bundle_id.bzl",
+    "BUNDLE_ID_PREFIX",
+    "example_provisioning",
+)
+
+licenses(["notice"])
+
+MIN_IOS_VERSION = "10.0"
+
+alias(
+    name = "objectrackinggpu",
+    actual = "ObjectTrackingGpuApp",
+)
+
+ios_application(
+    name = "ObjectTrackingGpuApp",
+    app_icons = ["//mediapipe/examples/ios/common:AppIcon"],
+    bundle_id = BUNDLE_ID_PREFIX + ".ObjectTrackingGpu",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//mediapipe/examples/ios/common:Info.plist",
+        "Info.plist",
+    ],
+    minimum_os_version = MIN_IOS_VERSION,
+    provisioning_profile = example_provisioning(),
+    deps = [
+        ":ObjectTrackingGpuAppLibrary",
+        "@ios_opencv//:OpencvFramework",
+    ],
+)
+
+objc_library(
+    name = "ObjectTrackingGpuAppLibrary",
+    data = [
+        "//mediapipe/graphs/tracking:mobile_gpu.binarypb",
+        "//mediapipe/models:ssdlite_object_detection.tflite",
+        "//mediapipe/models:ssdlite_object_detection_labelmap.txt",
+    ],
+    deps = [
+        "//mediapipe/examples/ios/common:CommonMediaPipeAppLibrary",
+    ] + select({
+        "//mediapipe:ios_i386": [],
+        "//mediapipe:ios_x86_64": [],
+        "//conditions:default": [
+            "//mediapipe/graphs/tracking:mobile_calculators",
+        ],
+    }),
+)

--- a/mediapipe/examples/ios/objecttrackinggpu/Info.plist
+++ b/mediapipe/examples/ios/objecttrackinggpu/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CameraPosition</key>
+  <string>front</string>
+  <key>GraphOutputStream</key>
+  <string>output_video</string>
+  <key>GraphInputStream</key>
+  <string>input_video</string>
+  <key>GraphName</key>
+  <string>mobile_gpu</string>
+</dict>
+</plist>

--- a/mediapipe/objc/MPPGraph.mm
+++ b/mediapipe/objc/MPPGraph.mm
@@ -45,7 +45,6 @@
 
   /// Number of frames currently being processed by the graph.
   std::atomic<int32_t> _framesInFlight;
-  /// Used as a sequential timestamp for MediaPipe.
   int64 _frameNumber;
 
   // Graph config modified to expose requested output streams.

--- a/mediapipe/objc/MPPGraph.mm
+++ b/mediapipe/objc/MPPGraph.mm
@@ -45,6 +45,8 @@
 
   /// Number of frames currently being processed by the graph.
   std::atomic<int32_t> _framesInFlight;
+  /// Used as a sequential timestamp for MediaPipe.
+  mediapipe::Timestamp _frameTimestamp;
   int64 _frameNumber;
 
   // Graph config modified to expose requested output streams.
@@ -367,16 +369,21 @@ void CallFrameDelegate(void* wrapperVoid, const std::string& streamName,
                      timestamp:timestamp
                 allowOverwrite:NO];
 }
+
 - (BOOL)sendPixelBuffer:(CVPixelBufferRef)imageBuffer
              intoStream:(const std::string&)inputName
              packetType:(MPPPacketType)packetType {
-  uint64_t us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::
-                                                                      now().time_since_epoch()).count();
+  _GTMDevAssert(_frameTimestamp < mediapipe::Timestamp::Done(),
+                @"Trying to send frame after stream is done.");
+  if (_frameTimestamp < mediapipe::Timestamp::Min()) {
+    _frameTimestamp = mediapipe::Timestamp::Min();
+  } else {
+    _frameTimestamp++;
+  }
   return [self sendPixelBuffer:imageBuffer
                     intoStream:inputName
                     packetType:packetType
-                     timestamp:mediapipe::Timestamp(us)];
-
+                     timestamp:_frameTimestamp];
 }
 
 - (void)debugPrintGlInfo {

--- a/mediapipe/objc/MPPGraph.mm
+++ b/mediapipe/objc/MPPGraph.mm
@@ -46,7 +46,6 @@
   /// Number of frames currently being processed by the graph.
   std::atomic<int32_t> _framesInFlight;
   /// Used as a sequential timestamp for MediaPipe.
-  mediapipe::Timestamp _frameTimestamp;
   int64 _frameNumber;
 
   // Graph config modified to expose requested output streams.
@@ -369,21 +368,16 @@ void CallFrameDelegate(void* wrapperVoid, const std::string& streamName,
                      timestamp:timestamp
                 allowOverwrite:NO];
 }
-
 - (BOOL)sendPixelBuffer:(CVPixelBufferRef)imageBuffer
              intoStream:(const std::string&)inputName
              packetType:(MPPPacketType)packetType {
-  _GTMDevAssert(_frameTimestamp < mediapipe::Timestamp::Done(),
-                @"Trying to send frame after stream is done.");
-  if (_frameTimestamp < mediapipe::Timestamp::Min()) {
-    _frameTimestamp = mediapipe::Timestamp::Min();
-  } else {
-    _frameTimestamp++;
-  }
+  uint64_t us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::
+                                                                      now().time_since_epoch()).count();
   return [self sendPixelBuffer:imageBuffer
                     intoStream:inputName
                     packetType:packetType
-                     timestamp:_frameTimestamp];
+                     timestamp:mediapipe::Timestamp(us)];
+
 }
 
 - (void)debugPrintGlInfo {


### PR DESCRIPTION
The problem is MPPGraph.mm uses frame sequential number as mediapipe timestamp which makes time sensitive logic failed in lots of calculators, such as PacketResamplerCalculator, BoxTrackerCalculator. 

The object tracking graph works perfectly on iOS after correcting timestamp to current microseconds.