### PR TITLE
doc: Add required Ubuntu packages for Python

### DIFF
--- a/docs/getting_started/building_examples.md
+++ b/docs/getting_started/building_examples.md
@@ -446,6 +446,8 @@ run `pip install mediapipe`, more convenient and much faster.
     $ sudo apt install python3-dev
     $ sudo apt install python3-venv
     $ sudo apt install -y protobuf-compiler
+    $ sudo apt install libprotobuf-dev
+    $ sudo apt install libgtk2.0-dev
     ```
 
     ```bash


### PR DESCRIPTION
The package `libprotobuf-dev` contains files of the sort `google/protobuf/any.proto`. If the package is missing, then `python3 setup.py gen_protos` fails.

If the package `libgtk2.0-dev` is not installed before opencv is build, then the example https://github.com/google/mediapipe/blob/f15da632dec186f2c1d3c780f47086477e2286a9/mediapipe/python/solutions/pose.py doesn't work with a live cam and it fails with the following error message:

```
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
Traceback (most recent call last):
  File "pose.py", line 28, in <module>
    cv2.imshow('MediaPipe Pose', image)
cv2.error: OpenCV(3.4.11) /tmp/pip-install-5y2ipa9p/opencv-python/opencv/modules/highgui/src/window.cpp:658: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Carbon support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvShowImage'
```