### PR TITLE
Fix links in javascript.md

### DIFF
--- a/docs/getting_started/javascript.md
+++ b/docs/getting_started/javascript.md
@@ -69,9 +69,9 @@ affecting your work, restrict your request to a `<minor>` number. e.g.,
 [F-npm]: https://www.npmjs.com/package/@mediapipe/face_mesh
 [H-npm]: https://www.npmjs.com/package/@mediapipe/hands
 [P-npm]: https://www.npmjs.com/package/@mediapipe/pose
-[draw-npm]: https://www.npmjs.com/package/@mediapipe/pose
-[cam-npm]: https://www.npmjs.com/package/@mediapipe/pose
-[ctrl-npm]: https://www.npmjs.com/package/@mediapipe/pose
+[draw-npm]: https://www.npmjs.com/package/@mediapipe/drawing_utils
+[cam-npm]: https://www.npmjs.com/package/@mediapipe/camera_utils
+[ctrl-npm]: https://www.npmjs.com/package/@mediapipe/control_utils
 [Ho-jsd]: https://www.jsdelivr.com/package/npm/@mediapipe/holistic
 [F-jsd]: https://www.jsdelivr.com/package/npm/@mediapipe/face_mesh
 [H-jsd]: https://www.jsdelivr.com/package/npm/@mediapipe/hands


### PR DESCRIPTION
The links for `control_utils`, `drawing_utils` and `camera_utils` are incorrect, and all lead to the pose npm site.                               
Have fixed this, please review and merge