### PR TITLE
Include android log library as part of JNI framework lib.

### DIFF
--- a/mediapipe/java/com/google/mediapipe/framework/jni/BUILD
+++ b/mediapipe/java/com/google/mediapipe/framework/jni/BUILD
@@ -113,6 +113,7 @@ cc_library(
         "//mediapipe:android": [
             "//mediapipe/util/android/file/base",
             "//mediapipe/util/android:asset_manager_util",
+            "//mediapipe/util/android:logging",
         ],
     }) + select({
         "//conditions:default": [

--- a/mediapipe/util/android/BUILD
+++ b/mediapipe/util/android/BUILD
@@ -53,4 +53,5 @@ cc_library(
         "-landroid",
         "-llog",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The Android logging library is not linked properly when declaring `mediapipe_aar` targets, leading to inconsistent app execution depending on the device (running on an Honor-20 but not on a Samsung Galaxy S20).

This PR includes two changes:

* It adds public visibility to `//mediapipe/util/android:logging` target.
* It includes `//mediapipe/util/android:logging` as part of `//mediapipe/java/com/google/mediapipe/framework/jni:mediapipe_framework_jni`