### PR TITLE
Bump protobuf to 3.15.1 to work around Bazel 4 incompatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,16 +125,16 @@ http_archive(
 # ...but the Java download is currently broken, so we use the "source" download.
 http_archive(
     name = "com_google_protobuf_javalite",
-    sha256 = "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9",
-    strip_prefix = "protobuf-3.11.4",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz"],
+    sha256 = "f18a40816260a9a3190a94efb0fc26270b244a2436681602f0a944739095d632",
+    strip_prefix = "protobuf-3.15.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.15.1.tar.gz"],
 )
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9",
-    strip_prefix = "protobuf-3.11.4",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz"],
+    sha256 = "f18a40816260a9a3190a94efb0fc26270b244a2436681602f0a944739095d632",
+    strip_prefix = "protobuf-3.15.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.15.1.tar.gz"],
     patches = [
         "@//third_party:com_google_protobuf_fixes.diff"
     ],

--- a/third_party/com_google_protobuf_fixes.diff
+++ b/third_party/com_google_protobuf_fixes.diff
@@ -1,140 +1,100 @@
 diff --git a/BUILD b/BUILD
-index 79871d621..51b3a063f 100644
+index 112432160..ab5e80ce2 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -26,7 +26,7 @@ config_setting(
+@@ -50,7 +50,7 @@ GTEST_MAIN = select({
  # ZLIB configuration
  ################################################################################
-
+ 
 -ZLIB_DEPS = ["@zlib//:zlib"]
 +ZLIB_DEPS = ["@zlib"]
-
+ 
  ################################################################################
  # Protobuf Runtime Library
-@@ -157,6 +157,7 @@ cc_library(
+@@ -200,6 +200,7 @@ cc_library(
      includes = ["src/"],
      linkopts = LINK_OPTS,
      visibility = ["//visibility:public"],
 +    alwayslink = 1,
  )
-
+ 
  PROTOBUF_DEPS = select({
-@@ -230,6 +231,7 @@ cc_library(
+@@ -273,6 +274,7 @@ cc_library(
      linkopts = LINK_OPTS,
      visibility = ["//visibility:public"],
      deps = [":protobuf_lite"] + PROTOBUF_DEPS,
 +    alwayslink = 1,
  )
-
+ 
  # This provides just the header files for use in projects that need to build
-@@ -318,13 +320,13 @@ cc_proto_library(
-
- [native_cc_proto_library(
-     name = proto + "_cc_proto",
--    deps = [proto + "_proto"],
-     visibility = ["//visibility:private"],
-+    deps = [proto + "_proto"],
- ) for proto in WELL_KNOWN_PROTO_MAP.keys()]
-
- cc_proto_blacklist_test(
-     name = "cc_proto_blacklist_test",
--    deps = [proto + "_cc_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()]
-+    deps = [proto + "_cc_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
- )
-
- ################################################################################
-@@ -900,7 +902,6 @@ py_proto_library(
-     py_extra_srcs = glob(["python/**/__init__.py"]),
+@@ -867,7 +869,6 @@ py_proto_library(
+     protoc = ":protoc",
      py_libs = [
          ":python_srcs",
 -        "@six//:six",
      ],
      srcs_version = "PY2AND3",
      visibility = ["//visibility:public"],
-@@ -1002,7 +1003,9 @@ cc_library(
- # Note: We use `native_proto_common` here because we depend on an implementation-detail of
- # `proto_lang_toolchain`, which may not be available on `proto_common`.
- reject_blacklisted_files = hasattr(native_proto_common, "proto_lang_toolchain_rejects_files_do_not_use_or_we_will_break_you_without_mercy")
-+
- cc_toolchain_blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()] if reject_blacklisted_files else [":well_known_protos"]
-+
- proto_lang_toolchain(
-     name = "cc_toolchain",
-     blacklisted_protos = cc_toolchain_blacklisted_protos,
-diff --git a/protobuf.bzl b/protobuf.bzl
-index 829464d44..4ac23594b 100644
---- a/protobuf.bzl
-+++ b/protobuf.bzl
-@@ -87,6 +87,8 @@ def _proto_gen_impl(ctx):
-     for dep in ctx.attr.deps:
-         import_flags += dep.proto.import_flags
-         deps += dep.proto.deps
-+    import_flags = depset(import_flags).to_list()
-+    deps = depset(deps).to_list()
-
-     if not ctx.attr.gen_cc and not ctx.attr.gen_py and not ctx.executable.plugin:
-         return struct(
 diff --git a/src/google/protobuf/io/gzip_stream.h b/src/google/protobuf/io/gzip_stream.h
-index b1ce1d36c..d5d560ea7 100644
+index b1ce1d36c..69ed1b996 100644
 --- a/src/google/protobuf/io/gzip_stream.h
 +++ b/src/google/protobuf/io/gzip_stream.h
-@@ -47,10 +47,12 @@
+@@ -47,10 +47,13 @@
  #include <google/protobuf/stubs/common.h>
  #include <google/protobuf/io/zero_copy_stream.h>
  #include <google/protobuf/port.h>
 -#include <zlib.h>
--
+ 
  #include <google/protobuf/port_def.inc>
-
+ 
 +#if HAVE_ZLIB
 +#include <zlib.h>
-+#endif  // HAVE_ZLIB
++#endif // HAVE_ZLIB
 +
  namespace google {
  namespace protobuf {
  namespace io {
-@@ -76,8 +78,10 @@ class PROTOBUF_EXPORT GzipInputStream : public ZeroCopyInputStream {
+@@ -76,8 +79,10 @@ class PROTOBUF_EXPORT GzipInputStream : public ZeroCopyInputStream {
    virtual ~GzipInputStream();
-
+ 
    // Return last error message or NULL if no error.
 +#if HAVE_ZLIB
    inline const char* ZlibErrorMessage() const { return zcontext_.msg; }
    inline int ZlibErrorCode() const { return zerror_; }
-+#endif  // HAVE_ZLIB
-
++#endif // HAVE_ZLIB
+ 
    // implements ZeroCopyInputStream ----------------------------------
    bool Next(const void** data, int* size);
-@@ -90,8 +94,10 @@ class PROTOBUF_EXPORT GzipInputStream : public ZeroCopyInputStream {
-
+@@ -90,8 +95,10 @@ class PROTOBUF_EXPORT GzipInputStream : public ZeroCopyInputStream {
+ 
    ZeroCopyInputStream* sub_stream_;
-
-+ #if HAVE_ZLIB
+ 
++#if HAVE_ZLIB
    z_stream zcontext_;
    int zerror_;
-+ #endif // HAVE_ZLIB
-
++#endif // HAVE_ZLIB
+ 
    void* output_buffer_;
    void* output_position_;
-@@ -142,9 +148,11 @@ class PROTOBUF_EXPORT GzipOutputStream : public ZeroCopyOutputStream {
-
+@@ -143,8 +150,10 @@ class PROTOBUF_EXPORT GzipOutputStream : public ZeroCopyOutputStream {
    virtual ~GzipOutputStream();
-
-+#if HAVE_ZLIB
+ 
    // Return last error message or NULL if no error.
++#if HAVE_ZLIB
    inline const char* ZlibErrorMessage() const { return zcontext_.msg; }
    inline int ZlibErrorCode() const { return zerror_; }
 +#endif  // HAVE_ZLIB
-
+ 
    // Flushes data written so far to zipped data in the underlying stream.
    // It is the caller's responsibility to flush the underlying stream if
-@@ -177,8 +185,10 @@ class PROTOBUF_EXPORT GzipOutputStream : public ZeroCopyOutputStream {
+@@ -177,8 +186,10 @@ class PROTOBUF_EXPORT GzipOutputStream : public ZeroCopyOutputStream {
    void* sub_data_;
    int sub_data_size_;
-
+ 
 +#if HAVE_ZLIB
    z_stream zcontext_;
    int zerror_;
 +#endif  //HAVE_ZLIB
    void* input_buffer_;
    size_t input_buffer_length_;
-
+ 


### PR DESCRIPTION
I ran into [this issue](https://github.com/bazelbuild/bazel/issues/12887) with building MediaPipe using Bazel 4.0.0. Apparently you need to use at least Protobuf 3.13 with Bazel 4.0.0.

This PR bumps Protobuf to 3.15.1.

I'm new to MediaPipe and Bazel. I'm not 100% sure I generated `third_party/com_google_protobuf_fixes.diff` correctly but it seems to work for me.