### PR TITLE
build objectron_detection_3d:mobile_calculators for iOS

### DIFF
--- a/mediapipe/modules/objectron/calculators/BUILD
+++ b/mediapipe/modules/objectron/calculators/BUILD
@@ -181,6 +181,15 @@ cc_library(
     hdrs = [
         "tensor_util.h",
     ],
+    copts = select({
+        # Needed for "//mediapipe/framework/formats:tensor" compatibility on Apple
+        # platforms for Metal pulled in via the tensor.h header.
+        "//mediapipe:apple": [
+            "-x objective-c++",
+            "-fobjc-arc",  # enable reference-counting
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//mediapipe/framework/formats:tensor",
         "//mediapipe/framework/port:logging",
@@ -296,6 +305,15 @@ cc_library(
     name = "lift_2d_frame_annotation_to_3d_calculator",
     srcs = ["lift_2d_frame_annotation_to_3d_calculator.cc"],
     visibility = ["//visibility:public"],
+    copts = select({
+        # Needed for "//mediapipe/framework/formats:tensor" compatibility on Apple
+        # platforms for Metal pulled in via the tensor.h header.
+        "//mediapipe:apple": [
+            "-x objective-c++",
+            "-fobjc-arc",  # enable reference-counting
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":annotation_cc_proto",
         ":belief_decoder_config_cc_proto",


### PR DESCRIPTION
This PR enables to build [object_detection_3d:mobile_calculators](https://github.com/google/mediapipe/blob/master/mediapipe/graphs/object_detection_3d/BUILD#L29) for iOS.

I referred to the following code.
https://github.com/google/mediapipe/blob/350fbb2100ad531bc110b93aaea23d96af5a5064/mediapipe/calculators/core/BUILD#L240-L248


I think other calculators that depends on `tensor_util` (e.g. `tflite_tensors_to_objects_calculator`) would also require the same options, but I leave them alone for now because I could not find where they are used.