### PR TITLE
fix: build inference_calculator_gl for android

### DIFF
--- a/mediapipe/calculators/tensor/BUILD
+++ b/mediapipe/calculators/tensor/BUILD
@@ -87,7 +87,12 @@ cc_library(
         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_buffer",
         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_program",
         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_shader",
-    ],
+    ] + select({
+        "//mediapipe:android": [
+            "//mediapipe/util/android/file/base",
+        ],
+        "//conditions:default": [],
+    }),
     alwayslink = 1,
 )
 


### PR DESCRIPTION
`inference_calculator_gl` includes header files under `mediapipe/util/android/file/base`, but those files are not declared in `deps`.
https://github.com/google/mediapipe/blob/350fbb2100ad531bc110b93aaea23d96af5a5064/mediapipe/calculators/tensor/inference_calculator_gl.cc#L32-L36

This PR adds those headers to `deps` explicitly.