### PR TITLE
Fixed inconsistent type in contract and open of input side packets

### DIFF
--- a/mediapipe/calculators/util/thresholding_calculator.cc
+++ b/mediapipe/calculators/util/thresholding_calculator.cc
@@ -101,7 +101,7 @@ absl::Status ThresholdingCalculator::Open(CalculatorContext* cc) {
   }
 
   if (cc->InputSidePackets().HasTag("THRESHOLD")) {
-    threshold_ = cc->InputSidePackets().Tag("THRESHOLD").Get<float>();
+    threshold_ = cc->InputSidePackets().Tag("THRESHOLD").Get<double>();
   }
   return absl::OkStatus();
 }


### PR DESCRIPTION
Inside ThresholdingCalculator::GetContract we are saying that it will be double but in actual open we expecting float. This fix just fixing this inconsistency.