### PR TITLE
Documentation Fix - Fixed Broken VisualStudio link

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -471,7 +471,7 @@ next section.
 4.  Install Visual C++ Build Tools 2019 and WinSDK
 
     Go to
-    [the VisualStudio website](ttps://visualstudio.microsoft.com/visual-cpp-build-tools),
+    [the VisualStudio website](https://visualstudio.microsoft.com/visual-cpp-build-tools),
     download build tools, and install Microsoft Visual C++ 2019 Redistributable
     and Microsoft Build Tools 2019.
 


### PR DESCRIPTION
The original link was missing the `h` in `https`, which means clicking the link leads to a broken address.