### PR TITLE
Documentation Fix: Missing mp_holistic in PoseEstimation example

### DIFF
--- a/docs/solutions/pose.md
+++ b/docs/solutions/pose.md
@@ -194,6 +194,7 @@ Supported configuration options:
 import cv2
 import mediapipe as mp
 mp_drawing = mp.solutions.drawing_utils
+mp_holistic = mp.solutions.holistic
 mp_pose = mp.solutions.pose
 
 # For static images:


### PR DESCRIPTION
Seems like the var `mp_holistic` is referenced without being instantiated. Also looks like the preference is to create `mp_x` var rather than `mp.solutions.holistic` inline, so done at the top with the others.