### PR TITLE
Fixes code visualization in objectron.md

### DIFF
--- a/docs/solutions/objectron.md
+++ b/docs/solutions/objectron.md
@@ -442,7 +442,7 @@ Example app bounding boxes are rendered with [GlAnimationOverlayCalculator](http
 > ```
 > and then run
 >
-> ```build
+> ```bash
 > bazel run -c opt mediapipe/graphs/object_detection_3d/obj_parser:ObjParser -- input_dir=[INTERMEDIATE_OUTPUT_DIR] output_dir=[OUTPUT_DIR]
 > ```
 > INPUT_DIR should be the folder with initial asset .obj files to be processed,


### PR DESCRIPTION
Fixes visualisation bug where the style of code "First run" is different from the code after "and then run"

<img width="1107" alt="Screenshot 2021-06-07 at 09 48 24" src="https://user-images.githubusercontent.com/8484196/120979141-9338b400-c775-11eb-8fc4-b774e10b7349.png">
