### PR TITLE
Fix installation guide

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -711,7 +711,7 @@ This will use a Docker image that will isolate mediapipe's installation from the
     ```bash
     $ docker run -it --name mediapipe mediapipe:latest
 
-    root@bca08b91ff63:/mediapipe# GLOG_logtostderr=1 bazel run --define MEDIAPIPE_DISABLE_GPU=1 mediapipe/examples/desktop/hello_world:hello_world
+    root@bca08b91ff63:/mediapipe# GLOG_logtostderr=1 bazelisk run --define MEDIAPIPE_DISABLE_GPU=1 mediapipe/examples/desktop/hello_world:hello_world
 
     # Should print:
     # Hello World!


### PR DESCRIPTION
Using Bazel fails to build the example codes. It should use Bazelisk to build here.