### PR TITLE
Fix anchor case

### DIFF
--- a/docs/solutions/pose.md
+++ b/docs/solutions/pose.md
@@ -141,7 +141,7 @@ Optionally, MediaPipe Pose can predicts a full-body
 Please find more detail in the
 [BlazePose Google AI Blog](https://ai.googleblog.com/2020/08/on-device-real-time-body-pose-tracking.html),
 this [paper](https://arxiv.org/abs/2006.10204),
-[the model card](./models.md#pose) and the [Output](#Output) section below.
+[the model card](./models.md#pose) and the [Output](#output) section below.
 
 ## Solution APIs
 


### PR DESCRIPTION
Anchor doesn't work on the website because anchors are case-sensitive.  This fixes that mistake for a link.