### PR TITLE
fix: TFLiteGPURunner crash on Linux when use_advanced_gpu_api is true

### DIFF
--- a/mediapipe/util/tflite/tflite_gpu_runner.cc
+++ b/mediapipe/util/tflite/tflite_gpu_runner.cc
@@ -252,8 +252,10 @@ absl::Status TFLiteGPURunner::InitializeOpenCL(
   MP_RETURN_IF_ERROR(cl_environment_->NewInferenceBuilder(
       cl_options, std::move(graph_cl), builder));
 
-#endif  // __ANDROID__
   return absl::OkStatus();
+#else
+  return mediapipe::UnimplementedError("Currently only Android is supported");
+#endif  // __ANDROID__
 }
 
 #ifdef __ANDROID__


### PR DESCRIPTION
Fixes #2170 and #2251.
