### PR TITLE
fix: check if ROI width and height is NaN

### DIFF
--- a/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc
+++ b/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc
@@ -670,7 +670,7 @@ absl::Status TensorsToDetectionsCalculator::ConvertToDetections(
         detection_boxes[box_offset + 2], detection_boxes[box_offset + 3],
         detection_scores[i], detection_classes[i], options_.flip_vertically());
     const auto& bbox = detection.location_data().relative_bounding_box();
-    if (bbox.width() < 0 || bbox.height() < 0) {
+    if (bbox.width() < 0 || bbox.height() < 0 || std::isnan(bbox.width()) || std::isnan(bbox.height())) {
       // Decoded detection boxes could have negative values for width/height due
       // to model prediction. Filter out those boxes since some downstream
       // calculators may assume non-negative values. (b/171391719)


### PR DESCRIPTION
Fixes https://github.com/google/mediapipe/issues/1965

When `//mediapipe/examples/desktop/hand_tracking:hand_tracking_gpu` or `//mediapipe/examples/desktop/pose_tracking:pose_tracking_gpu` is run on Linux, it crashes sometimes, especially just after camera starts or camera moves rapidly.
This issue occurs because widths and heights of detection's bounding boxes can be NaN.
This issue may be GPU-dependent, and I confirmed that it occurs with GeForce GTX TITAN X (driver version: 470.63.01).

Note that GPU sample (e.g. Pose Tracking, Holistic) may crash on Linux (cf. #2251) regardless of this.
