### PR TITLE
fix: Anchor is doubly defined

### DIFF
--- a/mediapipe/graphs/instant_motion_tracking/calculators/matrices_manager_calculator.cc
+++ b/mediapipe/graphs/instant_motion_tracking/calculators/matrices_manager_calculator.cc
@@ -58,7 +58,7 @@ constexpr float kInitialZ = -10.0f;
 //  perspective matrix]
 //
 // Input streams:
-//  ANCHORS - Anchor data with x,y,z coordinates (x,y are in [0.0-1.0] range for
+//  ANCHORS - Anchor3d data with x,y,z coordinates (x,y are in [0.0-1.0] range for
 //    position on the device screen, while z is the scaling factor that changes
 //    in proportion to the distance from the tracked region) [REQUIRED]
 //  IMU_ROTATION - float[9] of row-major device rotation matrix [REQUIRED]
@@ -101,7 +101,7 @@ class MatricesManagerCalculator : public CalculatorBase {
   const Matrix4fCM GenerateEigenModelMatrix(
       const Vector3f& translation_vector,
       const Matrix3f& rotation_submatrix) const;
-  const Vector3f GenerateAnchorVector(const Anchor& tracked_anchor) const;
+  const Vector3f GenerateAnchorVector(const Anchor3d& tracked_anchor) const;
   DiagonalMatrix3f GetDefaultRenderScaleDiagonal(
       const int render_id, const float user_scale_factor,
       const float gif_aspect_ratio) const;
@@ -145,7 +145,7 @@ absl::Status MatricesManagerCalculator::GetContract(CalculatorContract* cc) {
             cc->InputSidePackets().HasTag(kFOVSidePacketTag) &&
             cc->InputSidePackets().HasTag(kAspectRatioSidePacketTag));
 
-  cc->Inputs().Tag(kAnchorsTag).Set<std::vector<Anchor>>();
+  cc->Inputs().Tag(kAnchorsTag).Set<std::vector<Anchor3d>>();
   cc->Inputs().Tag(kIMUMatrixTag).Set<float[]>();
   cc->Inputs().Tag(kUserScalingsTag).Set<std::vector<UserScaling>>();
   cc->Inputs().Tag(kUserRotationsTag).Set<std::vector<UserRotation>>();
@@ -193,8 +193,8 @@ absl::Status MatricesManagerCalculator::Process(CalculatorContext* cc) {
   const std::vector<int> render_data =
       cc->Inputs().Tag(kRendersTag).Get<std::vector<int>>();
 
-  const std::vector<Anchor> anchor_data =
-      cc->Inputs().Tag(kAnchorsTag).Get<std::vector<Anchor>>();
+  const std::vector<Anchor3d> anchor_data =
+      cc->Inputs().Tag(kAnchorsTag).Get<std::vector<Anchor3d>>();
   if (cc->Inputs().HasTag(kGifAspectRatioTag) &&
       !cc->Inputs().Tag(kGifAspectRatioTag).IsEmpty()) {
     gif_aspect_ratio_ = cc->Inputs().Tag(kGifAspectRatioTag).Get<float>();
@@ -213,7 +213,7 @@ absl::Status MatricesManagerCalculator::Process(CalculatorContext* cc) {
   }
 
   int render_idx = 0;
-  for (const Anchor& anchor : anchor_data) {
+  for (const Anchor3d& anchor : anchor_data) {
     const int id = anchor.sticker_id;
     mediapipe::TimedModelMatrixProto* model_matrix;
     // Add model matrix to matrices list for defined object render ID
@@ -302,7 +302,7 @@ const Matrix3f MatricesManagerCalculator::GenerateUserRotationMatrix(
 // screen Using the sticker anchor data, a translation vector can be generated
 // in OpenGL coordinate space
 const Vector3f MatricesManagerCalculator::GenerateAnchorVector(
-    const Anchor& tracked_anchor) const {
+    const Anchor3d& tracked_anchor) const {
   // Using an initial z-value in OpenGL space, generate a new base z-axis value
   // to mimic scaling by distance.
   const float z = kInitialZ * tracked_anchor.z;

--- a/mediapipe/graphs/instant_motion_tracking/calculators/sticker_manager_calculator.cc
+++ b/mediapipe/graphs/instant_motion_tracking/calculators/sticker_manager_calculator.cc
@@ -61,7 +61,7 @@ class StickerManagerCalculator : public CalculatorBase {
               cc->Outputs().HasTag(kRenderDescriptorsTag));
 
     cc->Inputs().Tag(kProtoDataString).Set<std::string>();
-    cc->Outputs().Tag(kAnchorsTag).Set<std::vector<Anchor>>();
+    cc->Outputs().Tag(kAnchorsTag).Set<std::vector<Anchor3d>>();
     cc->Outputs().Tag(kUserRotationsTag).Set<std::vector<UserRotation>>();
     cc->Outputs().Tag(kUserScalingsTag).Set<std::vector<UserScaling>>();
     cc->Outputs().Tag(kRenderDescriptorsTag).Set<std::vector<int>>();
@@ -78,7 +78,7 @@ class StickerManagerCalculator : public CalculatorBase {
     std::string sticker_proto_string =
         cc->Inputs().Tag(kProtoDataString).Get<std::string>();
 
-    std::vector<Anchor> initial_anchor_data;
+    std::vector<Anchor3d> initial_anchor_data;
     std::vector<UserRotation> user_rotation_data;
     std::vector<UserScaling> user_scaling_data;
     std::vector<int> render_data;
@@ -91,7 +91,7 @@ class StickerManagerCalculator : public CalculatorBase {
 
     for (int i = 0; i < sticker_roll.sticker().size(); ++i) {
       // Declare empty structures for sticker data
-      Anchor initial_anchor;
+      Anchor3d initial_anchor;
       UserRotation user_rotation;
       UserScaling user_scaling;
       // Get individual Sticker object as defined by Protobuffer
@@ -116,7 +116,7 @@ class StickerManagerCalculator : public CalculatorBase {
     if (cc->Outputs().HasTag(kAnchorsTag)) {
       cc->Outputs()
           .Tag(kAnchorsTag)
-          .AddPacket(MakePacket<std::vector<Anchor>>(initial_anchor_data)
+          .AddPacket(MakePacket<std::vector<Anchor3d>>(initial_anchor_data)
                          .At(cc->InputTimestamp()));
     }
     if (cc->Outputs().HasTag(kUserRotationsTag)) {

--- a/mediapipe/graphs/instant_motion_tracking/calculators/tracked_anchor_manager_calculator.cc
+++ b/mediapipe/graphs/instant_motion_tracking/calculators/tracked_anchor_manager_calculator.cc
@@ -68,7 +68,7 @@ constexpr float kUsToMs =
 class TrackedAnchorManagerCalculator : public CalculatorBase {
  private:
   // Previous graph iteration anchor data
-  std::vector<Anchor> previous_anchor_data_;
+  std::vector<Anchor3d> previous_anchor_data_;
 
  public:
   static absl::Status GetContract(CalculatorContract* cc) {
@@ -77,14 +77,14 @@ class TrackedAnchorManagerCalculator : public CalculatorBase {
     RET_CHECK(cc->Outputs().HasTag(kAnchorsTag) &&
               cc->Outputs().HasTag(kBoxesOutputTag));
 
-    cc->Inputs().Tag(kAnchorsTag).Set<std::vector<Anchor>>();
+    cc->Inputs().Tag(kAnchorsTag).Set<std::vector<Anchor3d>>();
     cc->Inputs().Tag(kSentinelTag).Set<int>();
 
     if (cc->Inputs().HasTag(kBoxesInputTag)) {
       cc->Inputs().Tag(kBoxesInputTag).Set<mediapipe::TimedBoxProtoList>();
     }
 
-    cc->Outputs().Tag(kAnchorsTag).Set<std::vector<Anchor>>();
+    cc->Outputs().Tag(kAnchorsTag).Set<std::vector<Anchor3d>>();
     cc->Outputs().Tag(kBoxesOutputTag).Set<mediapipe::TimedBoxProtoList>();
 
     if (cc->Outputs().HasTag(kCancelTag)) {
@@ -103,10 +103,10 @@ REGISTER_CALCULATOR(TrackedAnchorManagerCalculator);
 absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
   mediapipe::Timestamp timestamp = cc->InputTimestamp();
   const int sticker_sentinel = cc->Inputs().Tag(kSentinelTag).Get<int>();
-  std::vector<Anchor> current_anchor_data =
-      cc->Inputs().Tag(kAnchorsTag).Get<std::vector<Anchor>>();
+  std::vector<Anchor3d> current_anchor_data =
+      cc->Inputs().Tag(kAnchorsTag).Get<std::vector<Anchor3d>>();
   auto pos_boxes = absl::make_unique<mediapipe::TimedBoxProtoList>();
-  std::vector<Anchor> tracked_scaled_anchor_data;
+  std::vector<Anchor3d> tracked_scaled_anchor_data;
 
   // Delete any boxes being tracked without an associated anchor
   for (const mediapipe::TimedBoxProto& box :
@@ -115,7 +115,7 @@ absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
            .Get<mediapipe::TimedBoxProtoList>()
            .box()) {
     bool anchor_exists = false;
-    for (Anchor anchor : current_anchor_data) {
+    for (Anchor3d anchor : current_anchor_data) {
       if (box.id() == anchor.sticker_id) {
         anchor_exists = true;
         break;
@@ -129,8 +129,8 @@ absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
   }
 
   // Perform tracking or updating for each anchor position
-  for (const Anchor& anchor : current_anchor_data) {
-    Anchor output_anchor = anchor;
+  for (const Anchor3d& anchor : current_anchor_data) {
+    Anchor3d output_anchor = anchor;
     // Check if anchor position is being reset by user in this graph iteration
     if (sticker_sentinel == anchor.sticker_id) {
       // Delete associated tracking box
@@ -150,7 +150,7 @@ absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
       // Default value for normalized z (scale factor)
       output_anchor.z = 1.0f;
     } else {
-      // Anchor position was not reset by user
+      // Anchor3d position was not reset by user
       // Attempt to update anchor position from tracking subgraph
       // (TimedBoxProto)
       bool updated_from_tracker = false;
@@ -175,7 +175,7 @@ absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
       // stickers to be tracked at approximately last location even if
       // re-acquisitioning in the BoxTrackingSubgraph encounters errors
       if (!updated_from_tracker) {
-        for (const Anchor& prev_anchor : previous_anchor_data_) {
+        for (const Anchor3d& prev_anchor : previous_anchor_data_) {
           if (anchor.sticker_id == prev_anchor.sticker_id) {
             mediapipe::TimedBoxProto* box = pos_boxes->add_box();
             box->set_left(prev_anchor.x - kBoxEdgeSize * 0.5f);
@@ -199,7 +199,7 @@ absl::Status TrackedAnchorManagerCalculator::Process(CalculatorContext* cc) {
 
   cc->Outputs()
       .Tag(kAnchorsTag)
-      .AddPacket(MakePacket<std::vector<Anchor>>(tracked_scaled_anchor_data)
+      .AddPacket(MakePacket<std::vector<Anchor3d>>(tracked_scaled_anchor_data)
                      .At(cc->InputTimestamp()));
   cc->Outputs()
       .Tag(kBoxesOutputTag)

--- a/mediapipe/graphs/instant_motion_tracking/calculators/transformations.h
+++ b/mediapipe/graphs/instant_motion_tracking/calculators/transformations.h
@@ -30,7 +30,7 @@ struct UserScaling {
 };
 
 // The normalized anchor coordinates of a sticker
-struct Anchor {
+struct Anchor3d {
   float x;  // [0.0-1.0]
   float y;  // [0.0-1.0]
   float z;  // Centered around 1.0 [current_scale = z * initial_scale]


### PR DESCRIPTION
Fixes #1617, #1887

This PR renames `Anchor` structure to `Anchor3d`.

Instant Motion Tracking uses a structure called [`Anchor`](https://github.com/google/mediapipe/blob/6abec128edd6d037e1a988605a59957c22f1e967/mediapipe/graphs/instant_motion_tracking/calculators/transformations.h#L32-L38) internally, but `Anchor` is also defined [here](https://github.com/google/mediapipe/blob/6abec128edd6d037e1a988605a59957c22f1e967/mediapipe/framework/formats/object_detection/anchor.proto#L19-L28).

When the app is built with `instant_motion_tracking_deps` and `face_detection:mobile_calculators`, especially with `-c=dbg`, it crashes randomly (see #1617).

