### PR TITLE
fix broken npm install snippet

### DIFF
--- a/docs/getting_started/javascript.md
+++ b/docs/getting_started/javascript.md
@@ -55,7 +55,7 @@ All of these solutions are staged in [NPM][npm]. You can install any package
 locally with `npm install`. Example:
 
 ```
-npm install @mediapipe/holistic.
+npm install @mediapipe/holistic
 ```
 
 If you would rather not stage these locally, you can rely on a CDN (e.g.,


### PR DESCRIPTION
current snippet gives an error due to an extra trailing period
```
❯ npm install @mediapipe/holistic.
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@mediapipe%2fholistic. - Not found
npm ERR! 404
npm ERR! 404  '@mediapipe/holistic.@*' is not in this registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jfperez/.npm/_logs/2021-11-19T07_24_18_780Z-debug.log
```