### PR TITLE
Update Docker File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ffmpeg \
         git \
         wget \
+        zip \
         unzip \
         python3-dev \
         python3-opencv \


### PR DESCRIPTION
Fix building pose_tracking AAR, using the following command:
bazel build --strip=always -s -c opt     --host_crosstool_top=@bazel_tools//tools/cpp:toolchain     --fat_apk_cpu=arm64-v8a,armeabi-v7a     //mediapipe/examples/android/src/java/com/google/mediapipe/apps/aar_example:mediapipe_pose_tracking.aar

Part of error message:
zip -r $origdir/bazel-out/k8-opt/bin/mediapipe/examples/android/src/java/com/google/mediapipe/apps/aar_example/mediapipe_pose_tracking.aar jni/*/*.so
')
ERROR: /mediapipe/mediapipe/examples/android/src/java/com/google/mediapipe/apps/aar_example/BUILD:3:14: Executing genrule //mediapipe/examples/android/src/java/com/google/mediapipe/apps/aar_example:mediapipe_pose_tracking failed: (Exit 127): bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)

By the error message, zip command is missing, I installed it and worked: apt-get update && apt-get install zip
But, it is best to place it on the DockerFile.