### PR TITLE
limiting axis values to solve issue #2918 (Pose or holistic solution leans the body forward in straight facing the camera pictures while plotting)

### DIFF
--- a/mediapipe/python/solutions/drawing_utils.py
+++ b/mediapipe/python/solutions/drawing_utils.py
@@ -282,6 +282,9 @@ def plot_landmarks(landmark_list: landmark_pb2.NormalizedLandmarkList,
   plt.figure(figsize=(10, 10))
   ax = plt.axes(projection='3d')
   ax.view_init(elev=elevation, azim=azimuth)
+  ax.set_xlim((-1,1))
+  ax.set_ylim((-1,1))
+  ax.set_zlim((-1,1))
   plotted_landmarks = {}
   for idx, landmark in enumerate(landmark_list.landmark):
     if ((landmark.HasField('visibility') and


### PR DESCRIPTION
Solving issue number (https://github.com/google/mediapipe/issues/2918) Pose or holistic solution leans the body forward in straight facing the camera pictures.

just added the limit to the axis values, as the values can be minimum -1 and maximum 1. Earlier there were no limits to axies values. It causes uneven points on each axis.