### PR TITLE
Introduced PacketRateCalculator.

### DIFF
--- a/mediapipe/calculators/core/BUILD
+++ b/mediapipe/calculators/core/BUILD
@@ -49,6 +49,40 @@ mediapipe_proto_library(
     ],
 )
 
+cc_library(
+    name = "packet_rate_calculator",
+    srcs = ["packet_rate_calculator.cc"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//mediapipe/framework:calculator_framework",
+        "//mediapipe/framework:collection_item_id",
+        "//mediapipe/framework/port:integral_types",
+        "//mediapipe/framework/port:logging",
+        "//mediapipe/framework/port:ret_check",
+        "//mediapipe/framework/port:status",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
+)
+
+cc_test(
+    name = "packet_rate_calculator_test",
+    timeout = "short",
+    srcs = [
+        "packet_rate_calculator_test.cc",
+    ],
+    deps = [
+        ":packet_rate_calculator",
+        "//mediapipe/framework:calculator_framework",
+        "//mediapipe/framework:calculator_runner",
+        "//mediapipe/framework/port:gtest_main",
+        "//mediapipe/framework/port:parse_text_proto",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 mediapipe_proto_library(
     name = "packet_resampler_calculator_proto",
     srcs = ["packet_resampler_calculator.proto"],

--- a/mediapipe/calculators/core/packet_rate_calculator.cc
+++ b/mediapipe/calculators/core/packet_rate_calculator.cc
@@ -1,0 +1,80 @@
+// Copyright 2022 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+#include <vector>
+
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/ret_check.h"
+#include "mediapipe/framework/port/status.h"
+
+namespace {
+using namespace mediapipe;
+/***
+ * PacketRateCalculator allows to calculate rate of incoming packages.
+ * E.g. when you want to extract FPS, or any other processing rate.
+ * As input it accepts any packets stream.
+ * As output it emits rate (floating point scalar), namely amount of packets per second based
+ * calculation of current packet and previous packet.
+ *
+ * For very first packet it emits empty packet.
+ *
+ * Usage example:
+ * node {
+ *   calculator: "PacketRateCalculator"
+ *   input_stream: "image"
+ *   output_stream: "image_fps"
+ * }
+ *
+ */
+class PacketRateCalculator : public CalculatorBase {
+public:
+  static absl::Status GetContract(CalculatorContract *cc) {
+    auto &side_inputs = cc->InputSidePackets();
+    RET_CHECK_EQ(cc->Inputs().NumEntries(), 1);
+    RET_CHECK_EQ(cc->Outputs().NumEntries(), 1);
+
+    cc->Inputs().Index(0).SetAny();
+
+    cc->Outputs().Index(0).Set<float>();
+    return absl::OkStatus();
+  }
+
+  absl::Status Open(CalculatorContext *cc) final { return absl::OkStatus(); }
+
+  // Releases input packets allowed by the max_in_flight constraint.
+  absl::Status Process(CalculatorContext *cc) final {
+    Timestamp latest_ts = cc->Inputs().Index(0).Value().Timestamp();
+
+    if (prev_timestamp_.Value() != kint64min) {
+      float seconds_since_last_packet = (latest_ts - prev_timestamp_).Seconds();
+      auto rate = std::make_unique<float>(1. / seconds_since_last_packet);
+      cc->Outputs().Index(0).Add(rate.release(), latest_ts);
+    } else {
+      cc->Outputs().Index(0).AddPacket(Packet().At(latest_ts));
+    }
+
+    prev_timestamp_ = latest_ts;
+
+    return absl::OkStatus();
+  }
+
+private:
+  Timestamp prev_timestamp_;
+};
+} // namespace
+
+namespace mediapipe {
+REGISTER_CALCULATOR(PacketRateCalculator);
+} // namespace mediapipe

--- a/mediapipe/calculators/core/packet_rate_calculator_test.cc
+++ b/mediapipe/calculators/core/packet_rate_calculator_test.cc
@@ -1,0 +1,64 @@
+// Copyright 2022 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/calculator_runner.h"
+#include "mediapipe/framework/port/gmock.h"
+#include "mediapipe/framework/port/gtest.h"
+#include "mediapipe/framework/port/parse_text_proto.h"
+#include "mediapipe/framework/port/status_matchers.h" // NOLINT
+
+namespace mediapipe {
+
+void AddInputVector(const std::vector<int> &input, int64 timestamp,
+                    CalculatorRunner *runner) {
+  runner->MutableInputs()->Index(0).packets.push_back(
+      MakePacket<std::vector<int>>(input).At(Timestamp(timestamp)));
+}
+
+TEST(PacketRateCalculatorTest, EmptyVectorInput) {
+
+  CalculatorGraphConfig::Node node_config =
+      ParseTextProtoOrDie<CalculatorGraphConfig::Node>(R"pb(
+        calculator: "PacketRateCalculator"
+        input_stream: "input_packet"
+        output_stream: "packet_rate"
+      )pb");
+
+  CalculatorRunner runner(node_config);
+
+  AddInputVector({0}, /*timestamp (microseconds)=*/1, &runner);
+  MP_ASSERT_OK(runner.Run());
+
+  EXPECT_EQ(0, runner.Outputs().Index(0).packets.size());
+
+  AddInputVector({1}, /*timestamp=*/1001, &runner);
+  MP_ASSERT_OK(runner.Run());
+
+  const std::vector<Packet> &outputs = runner.Outputs().Index(0).packets;
+  EXPECT_EQ(1, outputs.size());
+
+  // * first packet came with timestamp 1us
+  // * second packet has timestamp 1001us
+  // So period is 1ms, which equal to rate 1000 packets per second.
+
+  auto &v = outputs[0].Get<float>();
+  EXPECT_FLOAT_EQ(1e+3, v);
+}
+
+} // namespace mediapipe


### PR DESCRIPTION
PacketRateCalculator allows to calculate rate of incoming packages.
E.g. when you want to extract FPS, or any other processing rate.
* As input it accepts any packets stream.
* As output it emits rate (floating point scalar),
   namely amount of packets per second based
   calculation of current packet and previous packet.
* For very first packet it emits empty packet.

Usage example:
```
node {
  calculator: "PacketRateCalculator"
  input_stream: "image"
  output_stream: "image_fps"
}
```