### PR TITLE
Added import numpy statement for python

### DIFF
--- a/docs/solutions/holistic.md
+++ b/docs/solutions/holistic.md
@@ -251,6 +251,7 @@ Supported configuration options:
 *   [min_tracking_confidence](#min_tracking_confidence)
 
 ```python
+import numpy as np
 import cv2
 import mediapipe as mp
 mp_drawing = mp.solutions.drawing_utils

--- a/docs/solutions/pose.md
+++ b/docs/solutions/pose.md
@@ -257,6 +257,7 @@ Supported configuration options:
 *   [min_tracking_confidence](#min_tracking_confidence)
 
 ```python
+import numpy as np
 import cv2
 import mediapipe as mp
 mp_drawing = mp.solutions.drawing_utils


### PR DESCRIPTION
In the documentation for Pose and Holistic, for the python solution API, the code was not working without importing numpy, as the code is using the package, but its import statement was not there, Therefore I added `import numpy as np` statement.
The changes were done in the files:

- [solutions/pose.md](https://github.com/google/mediapipe/blob/master/docs/solutions/pose.md)
- [solutions/holistic.md](https://github.com/google/mediapipe/blob/master/docs/solutions/holistic.md)