### PR TITLE
Fix errors that will occur in Python 3.11

### DIFF
--- a/mediapipe/tasks/python/audio/audio_classifier.py
+++ b/mediapipe/tasks/python/audio/audio_classifier.py
@@ -70,7 +70,8 @@ class AudioClassifierOptions:
   """
   base_options: _BaseOptions
   running_mode: _RunningMode = _RunningMode.AUDIO_CLIPS
-  classifier_options: _ClassifierOptions = _ClassifierOptions()
+  classifier_options: Optional[_ClassifierOptions] = dataclasses.field(
+      default_factory=lambda: _ClassifierOptions())
   result_callback: Optional[Callable[[AudioClassifierResult, int], None]] = None
 
   @doc_controls.do_not_generate_docs

--- a/mediapipe/tasks/python/audio/audio_embedder.py
+++ b/mediapipe/tasks/python/audio/audio_embedder.py
@@ -71,7 +71,8 @@ class AudioEmbedderOptions:
   """
   base_options: _BaseOptions
   running_mode: _RunningMode = _RunningMode.AUDIO_CLIPS
-  embedder_options: _EmbedderOptions = _EmbedderOptions()
+  embedder_options: Optional[_EmbedderOptions] = dataclasses.field(
+      default_factory=lambda: _EmbedderOptions())
   result_callback: Optional[Callable[[AudioEmbedderResult, int], None]] = None
 
   @doc_controls.do_not_generate_docs

--- a/mediapipe/tasks/python/text/text_classifier.py
+++ b/mediapipe/tasks/python/text/text_classifier.py
@@ -14,6 +14,7 @@
 """MediaPipe text classifier task."""
 
 import dataclasses
+from typing import Optional
 
 from mediapipe.python import packet_creator
 from mediapipe.python import packet_getter
@@ -48,7 +49,8 @@ class TextClassifierOptions:
     classifier_options: Options for the text classification task.
   """
   base_options: _BaseOptions
-  classifier_options: _ClassifierOptions = _ClassifierOptions()
+  classifier_options: Optional[_ClassifierOptions] = dataclasses.field(
+      default_factory=lambda: _ClassifierOptions())
 
   @doc_controls.do_not_generate_docs
   def to_pb2(self) -> _TextClassifierGraphOptionsProto:

--- a/mediapipe/tasks/python/text/text_embedder.py
+++ b/mediapipe/tasks/python/text/text_embedder.py
@@ -14,6 +14,7 @@
 """MediaPipe text embedder task."""
 
 import dataclasses
+from typing import Optional
 
 from mediapipe.python import packet_creator
 from mediapipe.python import packet_getter
@@ -49,7 +50,8 @@ class TextEmbedderOptions:
     embedder_options: Options for the text embedder task.
   """
   base_options: _BaseOptions
-  embedder_options: _EmbedderOptions = _EmbedderOptions()
+  embedder_options: Optional[_EmbedderOptions] = dataclasses.field(
+      default_factory=lambda: _EmbedderOptions())
 
   @doc_controls.do_not_generate_docs
   def to_pb2(self) -> _TextEmbedderGraphOptionsProto:

--- a/mediapipe/tasks/python/vision/gesture_recognizer.py
+++ b/mediapipe/tasks/python/vision/gesture_recognizer.py
@@ -181,9 +181,11 @@ class GestureRecognizerOptions:
   min_hand_presence_confidence: Optional[float] = 0.5
   min_tracking_confidence: Optional[float] = 0.5
   canned_gesture_classifier_options: Optional[
-      _ClassifierOptions] = _ClassifierOptions()
+      _ClassifierOptions] = dataclasses.field(
+          default_factory=lambda: _ClassifierOptions())
   custom_gesture_classifier_options: Optional[
-      _ClassifierOptions] = _ClassifierOptions()
+      _ClassifierOptions] = dataclasses.field(
+          default_factory=lambda: _ClassifierOptions())
   result_callback: Optional[Callable[
       [GestureRecognizerResult, image_module.Image, int], None]] = None
 

--- a/mediapipe/tasks/python/vision/image_classifier.py
+++ b/mediapipe/tasks/python/vision/image_classifier.py
@@ -70,7 +70,8 @@ class ImageClassifierOptions:
   """
   base_options: _BaseOptions
   running_mode: _RunningMode = _RunningMode.IMAGE
-  classifier_options: _ClassifierOptions = _ClassifierOptions()
+  classifier_options: Optional[_ClassifierOptions] = dataclasses.field(
+      default_factory=lambda: _ClassifierOptions())
   result_callback: Optional[Callable[
       [ImageClassifierResult, image_module.Image, int], None]] = None
 

--- a/mediapipe/tasks/python/vision/image_embedder.py
+++ b/mediapipe/tasks/python/vision/image_embedder.py
@@ -69,7 +69,8 @@ class ImageEmbedderOptions:
   """
   base_options: _BaseOptions
   running_mode: _RunningMode = _RunningMode.IMAGE
-  embedder_options: _EmbedderOptions = _EmbedderOptions()
+  embedder_options: Optional[_EmbedderOptions] = dataclasses.field(
+      default_factory=lambda: _EmbedderOptions())
   result_callback: Optional[Callable[
       [ImageEmbedderResult, image_module.Image, int], None]] = None
 


### PR DESCRIPTION
- Use `default_factory` for mutable defaults