### PR TITLE
Updated iOS Naming Convention, Documentation and Formatting

### DIFF
--- a/mediapipe/tasks/ios/common/sources/MPPCommon.h
+++ b/mediapipe/tasks/ios/common/sources/MPPCommon.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * @enum MPPTasksErrorCode
- * This enum specifies  error codes for Mediapipe Task Library.
+ * This enum specifies  error codes for MediaPipe Task Library.
  * It maintains a 1:1 mapping to MediaPipeTasksStatus of the C ++libray.
  */
 typedef NS_ENUM(NSUInteger, MPPTasksErrorCode) {

--- a/mediapipe/tasks/ios/common/utils/sources/MPPCommonUtils.h
+++ b/mediapipe/tasks/ios/common/utils/sources/MPPCommonUtils.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Error domain of Mediapipe Task related errors. */
+/** Error domain of MediaPipe Task related errors. */
 extern NSString *const MPPTasksErrorDomain;
 
 /** Helper utility for the all tasks which encapsulates common functionality. */

--- a/mediapipe/tasks/ios/common/utils/sources/MPPCommonUtils.mm
+++ b/mediapipe/tasks/ios/common/utils/sources/MPPCommonUtils.mm
@@ -96,7 +96,7 @@ NSString *const MPPTasksErrorDomain = @"com.google.mediapipe.tasks";
   // The mapping to absl::Status::code() is done to generate a more specific error code than
   // MPPTasksErrorCodeError in cases when the payload can't be mapped to
   // MPPTasksErrorCode. This can happen when absl::Status returned by TFLite library are in turn
-  // returned without modification by Mediapipe cc library methods.
+  // returned without modification by MediaPipe cc library methods.
   if (errorCode > MPPTasksErrorCodeLast || errorCode <= MPPTasksErrorCodeFirst) {
     switch (status.code()) {
       case absl::StatusCode::kInternal:

--- a/mediapipe/tasks/ios/core/sources/MPPTaskOptions.h
+++ b/mediapipe/tasks/ios/core/sources/MPPTaskOptions.h
@@ -25,7 +25,7 @@ NS_SWIFT_NAME(TaskOptions)
 
 @interface MPPTaskOptions : NSObject <NSCopying>
 /**
- * Base options for configuring the Mediapipe task.
+ * Base options for configuring the MediaPipe task.
  */
 @property(nonatomic, copy) MPPBaseOptions *baseOptions;
 

--- a/mediapipe/tasks/ios/core/sources/MPPTaskOptions.m
+++ b/mediapipe/tasks/ios/core/sources/MPPTaskOptions.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "mediapipe/tasks/ios/core/sources/MPPTaskOptions.h"
+
 #import "mediapipe/tasks/ios/core/sources/MPPBaseOptions.h"
 
 @implementation MPPTaskOptions

--- a/mediapipe/tasks/ios/core/sources/MPPTaskResult.h
+++ b/mediapipe/tasks/ios/core/sources/MPPTaskResult.h
@@ -26,11 +26,11 @@ NS_SWIFT_NAME(TaskResult)
 /**
  * Timestamp that is associated with the task result object.
  */
-@property(nonatomic, assign, readonly) long timestamp;
+@property(nonatomic, assign, readonly) NSInteger timestampMs;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithTimestamp:(long)timestamp NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTimestampMs:(NSInteger)timestampMs NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/mediapipe/tasks/ios/core/sources/MPPTaskResult.m
+++ b/mediapipe/tasks/ios/core/sources/MPPTaskResult.m
@@ -16,16 +16,16 @@
 
 @implementation MPPTaskResult
 
-- (instancetype)initWithTimestamp:(long)timestamp {
+- (instancetype)initWithTimestampMs:(NSInteger)timestampMs {
   self = [super init];
   if (self) {
-    _timestamp = timestamp;
+    _timestampMs = timestampMs;
   }
   return self;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-  return [[MPPTaskResult alloc] initWithTimestamp:self.timestamp];
+  return [[MPPTaskResult alloc] initWithTimestampMs:self.timestampMs];
 }
 
 @end

--- a/mediapipe/tasks/ios/core/sources/MPPTextPacketCreator.mm
+++ b/mediapipe/tasks/ios/core/sources/MPPTextPacketCreator.mm
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "mediapipe/tasks/ios/core/sources/MPPTextPacketCreator.h"
+
 #import "mediapipe/tasks/ios/common/utils/sources/NSString+Helpers.h"
 
 namespace {


### PR DESCRIPTION
1. Updated existing C++ variables to follow camel case naming convention in .mm files.
2. Updated to correct spelling of "MediaPipe" in iOS files.
3. Changed Formatting