### PR TITLE
Fix: [Python] NamedTuple SolutionOutputs is not actually a NamedTuple

### DIFF
--- a/mediapipe/python/solution_base.py
+++ b/mediapipe/python/solution_base.py
@@ -366,17 +366,15 @@ class SolutionBase:
     # Create a NamedTuple object where the field names are mapping to the graph
     # output stream names.
     solution_outputs = collections.namedtuple(
-        'SolutionOutputs', self._output_stream_type_info.keys())
+          'SolutionOutputs', self._output_stream_type_info.keys())
+    empty_list = [[] for _ in range(len(solution_outputs._fields))]
+    results = solution_outputs(*(empty_list))
     for stream_name in self._output_stream_type_info.keys():
-      if stream_name in self._graph_outputs:
-        setattr(
-            solution_outputs, stream_name,
-            self._get_packet_content(self._output_stream_type_info[stream_name],
-                                     self._graph_outputs[stream_name]))
-      else:
-        setattr(solution_outputs, stream_name, None)
-
-    return solution_outputs
+        if stream_name in self._graph_outputs:
+            results = results._replace(**{stream_name: self._get_packet_content(
+                self._output_stream_type_info[stream_name], self._graph_outputs[stream_name])})
+                
+    return results
 
   def close(self) -> None:
     """Closes all the input sources and the graph."""


### PR DESCRIPTION
This fixes NamedTuple class methods unable to be called in issue #3257.  
