### PR TITLE
Update 11-tasks-issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/11-tasks-issue.md
+++ b/.github/ISSUE_TEMPLATE/11-tasks-issue.md
@@ -1,7 +1,7 @@
 ---
 name: "Tasks Issue"
 about: Use this template for assistance with using MediaPipe Tasks (developers.google.com/mediapipe/solutions) to deploy on-device ML solutions (e.g. gesture recognition etc.) on supported platforms.
-labels: type:support
+labels: type:tasks
 
 ---
 <em>Please make sure that this is a [Tasks](https://developers.google.com/mediapipe/solutions) issue.<em>


### PR DESCRIPTION
Fix the label type:tasks under template of new tasks Issue currently default label type is type:support