### PR TITLE
Fix Broken Link in Object Detection solutions

### DIFF
--- a/docs/solutions/object_detection.md
+++ b/docs/solutions/object_detection.md
@@ -108,9 +108,9 @@ on how to build MediaPipe examples.
 *   With a TensorFlow Model
 
     This uses the
-    [TensorFlow model](https://github.com/google/mediapipe/tree/master/mediapipe/models/object_detection_saved_model)
+    [TensorFlow model](https://github.com/google/mediapipe/tree/master/mediapipe/graphs/object_detection)
     ( see also
-    [model info](https://github.com/google/mediapipe/tree/master/mediapipe/models/object_detection_saved_model/README.md)),
+    [model info](https://github.com/google/mediapipe/tree/master/mediapipe/modules/objectron)),
     and the pipeline is implemented in this
     [graph](https://github.com/google/mediapipe/tree/master/mediapipe/graphs/object_detection/object_detection_mobile_cpu.pbtxt).
 


### PR DESCRIPTION
The documentation on [Object Detection](https://google.github.io/mediapipe/solutions/object_detection.html) contains three broken links. Since the code is implemented `graphs` saved models. I have fixed the broken link, I hope it is now redirecting to the correct solution.

Before: `Broken Link`
```
https://github.com/google/mediapipe/tree/master/mediapipe/models/object_detection_saved_model
```

After: Saved models uses to implement `graphs`,
```
https://github.com/google/mediapipe/tree/master/mediapipe/graphs/object_detection
```