### PR TITLE
fix: add missing tflite model to BUILD

### DIFF
--- a/mediapipe/examples/desktop/face_mesh/BUILD
+++ b/mediapipe/examples/desktop/face_mesh/BUILD
@@ -18,7 +18,10 @@ package(default_visibility = ["//mediapipe/examples:__subpackages__"])
 
 cc_binary(
     name = "face_mesh_tflite",
-    data = ["//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite"],
+    data = [
+        "//mediapipe/modules/face_detection:face_detection_short_range.tflite",
+        "//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite",
+    ],
     deps = [
         "//mediapipe/examples/desktop:simple_run_graph_main",
         "//mediapipe/graphs/face_mesh:desktop_calculators",
@@ -27,7 +30,10 @@ cc_binary(
 
 cc_binary(
     name = "face_mesh_cpu",
-    data = ["//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite"],
+    data = [
+        "//mediapipe/modules/face_detection:face_detection_short_range.tflite",
+        "//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite",      
+    ],
     deps = [
         "//mediapipe/examples/desktop:demo_run_graph_main",
         "//mediapipe/graphs/face_mesh:desktop_live_calculators",
@@ -37,7 +43,10 @@ cc_binary(
 # Linux only
 cc_binary(
     name = "face_mesh_gpu",
-    data = ["//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite"],
+    data = [
+        "//mediapipe/modules/face_detection:face_detection_short_range.tflite",
+        "//mediapipe/modules/face_landmark:face_landmark_with_attention.tflite",
+    ],
     deps = [
         "//mediapipe/examples/desktop:demo_run_graph_main_gpu",
         "//mediapipe/graphs/face_mesh:desktop_live_gpu_calculators",

--- a/mediapipe/examples/desktop/holistic_tracking/BUILD
+++ b/mediapipe/examples/desktop/holistic_tracking/BUILD
@@ -19,6 +19,7 @@ package(default_visibility = ["//mediapipe/examples:__subpackages__"])
 cc_binary(
     name = "holistic_tracking_cpu",
     data = [
+        "//mediapipe/modules/face_detection:face_detection_short_range.tflite",
         "//mediapipe/modules/face_landmark:face_landmark.tflite",
         "//mediapipe/modules/hand_landmark:hand_landmark_full.tflite",
         "//mediapipe/modules/holistic_landmark:hand_recrop.tflite",
@@ -35,6 +36,7 @@ cc_binary(
 cc_binary(
     name = "holistic_tracking_gpu",
     data = [
+        "//mediapipe/modules/face_detection:face_detection_short_range.tflite",
         "//mediapipe/modules/face_landmark:face_landmark.tflite",
         "//mediapipe/modules/hand_landmark:hand_landmark_full.tflite",
         "//mediapipe/modules/holistic_landmark:hand_recrop.tflite",


### PR DESCRIPTION
After being updated to download tflite files from gcp, the necessary tflite files have to be specified in BUILD. 
In the face mesh and holistic examples, the tflite file required for face detection was missing.
When examples are build and run for the first time, an error occurs that the face detection model cannot be found.