### PR TITLE
Fix: [begin_loop_calculator] Timestamp bound is not propagated for empty CLONE inputs

### DIFF
--- a/mediapipe/calculators/core/begin_loop_calculator.h
+++ b/mediapipe/calculators/core/begin_loop_calculator.h
@@ -175,6 +175,11 @@ class BeginLoopCalculator : public CalculatorBase {
           cc->Outputs()
               .Get("CLONE", i)
               .AddPacket(std::move(input_packet).At(output_timestamp));
+        } else {
+          // In case the clone input stream is empty, timestamp bound needs to be updated so that downstream calculators don't have to wait
+          // Increment output_timestamp by 1 to signal that the output is empty for current timestamp. This allows downstream calculators
+          // to start processing on their current inputs.
+          cc->Outputs().Get("CLONE", i).SetNextTimestampBound(output_timestamp + 1);
         }
       }
     }


### PR DESCRIPTION
This PR fixes the bug in `begin_loop_calculator.h` that timestamp bound isn't propagated when `CLONE` inputs are empty.

The timestamp bound is only updated when:
- `CLONE` input is not empty
- `ITERABLE` input is empty (all outputs are updated with the same timestamp bound)
Therefore, when `CLONE` input is empty, no timestamp bound update can make downstream calculators using the `CLONE` streams buffer their inputs for no reason and delay the processing until the whole loop is done.
