### PR TITLE
docs: improved README & fixed multiple typos   

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,8 @@ as the primary developer documentation site for MediaPipe as of April 3, 2023.*
 
 *This notice and web page will be removed on June 1, 2023.*
 
-----
-
-<br><br><br><br><br><br><br><br><br><br>
-<br><br><br><br><br><br><br><br><br><br>
-<br><br><br><br><br><br><br><br><br><br>
-
 --------------------------------------------------------------------------------
+<br/>
 
 ## Live ML anywhere
 

--- a/docs/getting_started/faq.md
+++ b/docs/getting_started/faq.md
@@ -53,7 +53,7 @@ calculators need only to be *thread-compatible* and not *thread-safe*.
 In order to enable one calculator to process multiple inputs in parallel, there
 are two possible approaches:
 
-1.  Define multiple calulator nodes and dispatch input packets to all nodes.
+1.  Define multiple calculator nodes and dispatch input packets to all nodes.
 2.  Make the calculator thread-safe and configure its [`max_in_flight`] setting.
 
 The first approach can be followed using the calculators designed to distribute
@@ -95,12 +95,12 @@ while the application is running:
 The first approach has the advantage of leveraging [`CalculatorGraphConfig`]
 processing tools such as "subgraphs". The second approach has the advantage of
 allowing active calculators and packets to remain in-flight while settings
-change. Mediapipe contributors are currently investigating alternative approaches
+change. MediaPipe contributors are currently investigating alternative approaches
 to achieve both of these advantages.
 
 ### How to process realtime input streams
 
-The mediapipe framework can be used to process data streams either online or
+The MediaPipe framework can be used to process data streams either online or
 offline. For offline processing, packets are pushed into the graph as soon as
 calculators are ready to process those packets. For online processing, one
 packet for each frame is pushed into the graph as that frame is recorded.

--- a/docs/getting_started/ios.md
+++ b/docs/getting_started/ios.md
@@ -120,8 +120,8 @@ allows you to make use of automatic provisioning (see later section).
 To install applications on an iOS device, you need a provisioning profile. There
 are two options:
 
-1.  Automatic provisioning. This allows you to build and install an app to your
-    personal device. The provisining profile is managed by Xcode, and has to be
+1.  Automatic provisioning. This allows you to build and install an app on your
+    personal device. The provisioning profile is managed by Xcode, and has to be
     updated often (it is valid for about a week).
 
 2.  Custom provisioning. This uses a provisioning profile associated with an
@@ -186,7 +186,7 @@ Profiles"`. If there are none, generate and download a profile on
 Note: if you had previously set up automatic provisioning, you should remove the
 `provisioning_profile.mobileprovision` symlink in each example's directory,
 since it will take precedence over the common one. You can also overwrite it
-with you own profile if you need a different profile for different apps.
+with your own profile if you need a different profile for different apps.
 
 1.  Open `mediapipe/examples/ios/bundle_id.bzl`, and change the
     `BUNDLE_ID_PREFIX` to a prefix associated with your provisioning profile.
@@ -203,7 +203,7 @@ Note: When you ask Xcode to run an app, by default it will use the Debug
 configuration. Some of our demos are computationally heavy; you may want to use
 the Release configuration for better performance.
 
-Note: Due to an imcoptibility caused by one of our dependencies, MediaPipe
+Note: Due to an incompatibility caused by one of our dependencies, MediaPipe
 cannot be used for apps running on the iPhone Simulator on Apple Silicon (M1).
 
 Tip: To switch build configuration in Xcode, click on the target menu, choose

--- a/docs/getting_started/python_framework.md
+++ b/docs/getting_started/python_framework.md
@@ -81,7 +81,7 @@ np.ndarray                           | mp::Matrix                    | create_ma
 Google Proto Message                 | Google Proto Message          | create_proto(proto)                                                                                                                                          | get_proto(packet)
 List\[Proto\]                        | std::vector\<Proto\>          | n/a                                                                                                                                                          | get_proto_list(packet)
 
-It's not uncommon that users create custom C++ classes and and send those into
+It's not uncommon that users create custom C++ classes and send those into
 the graphs and calculators. To allow the custom classes to be used in Python
 with MediaPipe, you may extend the Packet API for a new data type in the
 following steps:
@@ -234,7 +234,7 @@ three stages: initialization and setup, graph run, and graph shutdown.
             output_packets.append(mp.packet_getter.get_str(packet)))
     ```
 
-    Option 2. Initialize a CalculatorGraph with with a binary protobuf file, and
+    Option 2. Initialize a CalculatorGraph with a binary protobuf file, and
     observe the output stream(s).
 
     ```python

--- a/docs/solutions/holistic.md
+++ b/docs/solutions/holistic.md
@@ -75,7 +75,7 @@ previous frame as a guide to the object region on the current one. However,
 during fast movements, the tracker can lose the target, which requires the
 detector to re-localize it in the image. MediaPipe Holistic uses
 [pose](./pose.md) prediction (on every frame) as an additional ROI prior to
-reduce the response time of the pipeline when reacting to fast movements. This
+reducing the response time of the pipeline when reacting to fast movements. This
 also enables the model to retain semantic consistency across the body and its
 parts by preventing a mixup between left and right hands or body parts of one
 person in the frame with another.

--- a/docs/solutions/pose.md
+++ b/docs/solutions/pose.md
@@ -143,7 +143,7 @@ The landmark model in MediaPipe Pose predicts the location of 33 pose landmarks
 :----------------------------------------------------------------------------------------------: |
 *Fig 4. 33 pose landmarks.*                                                                      |
 
-Optionally, MediaPipe Pose can predicts a full-body
+Optionally, MediaPipe Pose can predict a full-body
 [segmentation mask](#segmentation_mask) represented as a two-class segmentation
 (human or background).
 


### PR DESCRIPTION
#### Description

The mid-section of the [`README`](https://github.com/google/mediapipe/blob/master/README.md) file seems blank & has been produced with too many unnecessary _[breaks](https://github.com/google/mediapipe/issues/4247#:~:text=visuals%2C%20if%20applicable-,Check%20this,-%E2%AC%87%EF%B8%8F)_.

https://github.com/google/mediapipe/blob/065d7507818e9bf6f93ae38cbab805c6a4414907/README.md?plain=1#L19-L21

Additionally, fixed a bunch of typos and grammatical mistakes in several docs(guides).

Resolves: #4247
cc: @kuaashish
