### PR TITLE
fix: landmark_projection_calculator's projection function for general case when using rect input.

### DIFF
--- a/mediapipe/calculators/util/landmark_projection_calculator.cc
+++ b/mediapipe/calculators/util/landmark_projection_calculator.cc
@@ -168,8 +168,6 @@ class LandmarkProjectionCalculator : public CalculatorBase {
           cc->Options<mediapipe::LandmarkProjectionCalculatorOptions>();
       project_fn = [&input_rect, &options](const NormalizedLandmark& landmark,
                                            NormalizedLandmark* new_landmark) {
-        // TODO: fix projection or deprecate (current projection
-        // calculations are incorrect for general case).
         const float x = landmark.x() - 0.5f;
         const float y = landmark.y() - 0.5f;
         const float angle =
@@ -177,8 +175,12 @@ class LandmarkProjectionCalculator : public CalculatorBase {
         float new_x = std::cos(angle) * x - std::sin(angle) * y;
         float new_y = std::sin(angle) * x + std::cos(angle) * y;
 
-        new_x = new_x * input_rect.width() + input_rect.x_center();
-        new_y = new_y * input_rect.height() + input_rect.y_center();
+        // input_rect's x_min and y_min may be smaller than 0, so limit the lower bound with 0
+        const float rect_x_min = std::max(0.f, input_rect.x_center() - input_rect.width() * 0.5f);
+        const float rect_y_min = std::max(0.f, input_rect.y_center() - input_rect.height() * 0.5f);
+
+        new_x = (new_x + 0.5f) * input_rect.width() + rect_x_min;
+        new_y = (new_y + 0.5f) * input_rect.height() + rect_y_min;
         const float new_z =
             landmark.z() * input_rect.width();  // Scale Z coordinate as X.
 


### PR DESCRIPTION
This PR fixes the landmark projection calculator's projection function when using a normalized rectangle as input.

The normalized rectangle's areas may be out of range of the image, so the result may be incorrect.
