### PR TITLE
Externalize mediapipe_aar

### DIFF
--- a/mediapipe/framework/BUILD
+++ b/mediapipe/framework/BUILD
@@ -97,7 +97,7 @@ mediapipe_proto_library(
     name = "mediapipe_options_proto",
     srcs = ["mediapipe_options.proto"],
     visibility = [
-        ":mediapipe_internal",
+        "//visibility:public",
     ],
 )
 
@@ -126,14 +126,14 @@ mediapipe_proto_library(
 mediapipe_proto_library(
     name = "status_handler_proto",
     srcs = ["status_handler.proto"],
-    visibility = [":mediapipe_internal"],
+    visibility = ["//visibility:public"],
     deps = [":mediapipe_options_proto"],
 )
 
 mediapipe_proto_library(
     name = "stream_handler_proto",
     srcs = ["stream_handler.proto"],
-    visibility = [":mediapipe_internal"],
+    visibility = ["//visibility:public"],
     deps = [":mediapipe_options_proto"],
 )
 

--- a/mediapipe/framework/tool/mediapipe_graph.bzl
+++ b/mediapipe/framework/tool/mediapipe_graph.bzl
@@ -247,10 +247,10 @@ def mediapipe_options_library(
         name = name + "_type_name",
         srcs = [proto_lib + "_direct-direct-descriptor-set.proto.bin"],
         outs = [name + "_type_name.h"],
-        cmd = ("$(location " + "//mediapipe/framework/tool:message_type_util" + ") " +
+        cmd = ("$(location " + clean_dep("//mediapipe/framework/tool:message_type_util") + ") " +
                ("--input_path=$(location %s) " % (proto_lib + "_direct-direct-descriptor-set.proto.bin")) +
                ("--root_type_macro_output_path=$(location %s) " % (name + "_type_name.h"))),
-        tools = ["//mediapipe/framework/tool:message_type_util"],
+        tools = [clean_dep("//mediapipe/framework/tool:message_type_util")],
         visibility = visibility,
         testonly = testonly,
         compatible_with = compatible_with,

--- a/mediapipe/java/com/google/mediapipe/components/BUILD
+++ b/mediapipe/java/com/google/mediapipe/components/BUILD
@@ -94,5 +94,5 @@ android_library(
 filegroup(
     name = "java_src",
     srcs = glob(["*.java"]),
-    visibility = ["//mediapipe:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/mediapipe/java/com/google/mediapipe/framework/BUILD
+++ b/mediapipe/java/com/google/mediapipe/framework/BUILD
@@ -145,5 +145,5 @@ filegroup(
         ["*.java"],
         exclude = ["TypeNameRegistryFull.java"],
     ),
-    visibility = ["//mediapipe:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/mediapipe/java/com/google/mediapipe/glutil/BUILD
+++ b/mediapipe/java/com/google/mediapipe/glutil/BUILD
@@ -35,5 +35,5 @@ android_library(
 filegroup(
     name = "java_src",
     srcs = glob(["**/*.java"]),
-    visibility = ["//mediapipe:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Cleans up labels used in mediapipe_aar.bzl and mediapipe_graph.bzl so that mediapipe_aar macro is correctly expanded when used from a different repository.

Also changes the visibility of rules used by the macro.