### PR TITLE
Update docs in bounding_box.d.ts

### DIFF
--- a/mediapipe/tasks/web/components/containers/bounding_box.d.ts
+++ b/mediapipe/tasks/web/components/containers/bounding_box.d.ts
@@ -16,9 +16,9 @@
 
 /** An integer bounding box, axis aligned. */
 export declare interface BoundingBox {
-  /** The X coordinate of the top-left corner, in pixels. */
+  /** The X coordinate of the bottom-left corner, in pixels. */
   originX: number;
-  /** The Y coordinate of the top-left corner, in pixels. */
+  /** The Y coordinate of the bottom-left corner, in pixels. */
   originY: number;
   /** The width of the bounding box, in pixels. */
   width: number;


### PR DESCRIPTION
The BoundingBox origin point (x_origin, y_origin) is in the bottom left corner, not the top left. 