### PR TITLE
Update setup_opencv.sh

### DIFF
--- a/setup_opencv.sh
+++ b/setup_opencv.sh
@@ -40,7 +40,7 @@ if [ -z "$1" ]
     echo "Installing OpenCV from source"
     if [[ -x "$(command -v apt)" ]]; then
       sudo apt update && sudo apt install build-essential git
-      sudo apt install cmake ffmpeg libavformat-dev libdc1394-22-dev libgtk2.0-dev \
+      sudo apt install cmake ffmpeg libavformat-dev libdc1394-dev libgtk2.0-dev \
                        libjpeg-dev libpng-dev libswscale-dev libtbb2 libtbb-dev \
                        libtiff-dev
     elif [[ -x "$(command -v dnf)" ]]; then


### PR DESCRIPTION
libdc1394-22-dev has been orphaned and removed from debian and replaced by libdc1394-dev. You can reference this. https://bugs.debian.org/963924