### PR TITLE
Update Dockerfile to fix bazel install issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,14 +63,14 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Install bazel
 ARG BAZEL_VERSION=6.1.1
 RUN mkdir /bazel && \
-    wget --no-check-certificate -O /bazel/installer.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/b\
-azel-${BAZEL_VERSION}-installer-linux-x86_64.sh" && \
+    wget --no-check-certificate -O /bazel/installer.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh" && \
     wget --no-check-certificate -O  /bazel/LICENSE.txt "https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE" && \
     chmod +x /bazel/installer.sh && \
     /bazel/installer.sh  && \
     rm -f /bazel/installer.sh
 
 COPY . /mediapipe/
+RUN sed $'s/\r$//' .bazelversion > .bazelversion
 
 # If we want the docker image to contain the pre-built object_detection_offline_demo binary, do the following
 # RUN bazel build -c opt --define MEDIAPIPE_DISABLE_GPU=1 mediapipe/examples/desktop/demo:object_detection_tensorflow_demo


### PR DESCRIPTION
.bazelversion is CRLF which causes an issue with bazel on the linux docker image

Plus wget target url split over 2 lines also causes issues on linux docker image