### PR TITLE
add read_as_binary parameter for custom resource providers

### DIFF
--- a/mediapipe/util/resource_util.cc
+++ b/mediapipe/util/resource_util.cc
@@ -32,7 +32,7 @@ ResourceProviderFn resource_provider_ = nullptr;
 absl::Status GetResourceContents(const std::string& path, std::string* output,
                                  bool read_as_binary) {
   if (resource_provider_) {
-    return resource_provider_(path, output);
+    return resource_provider_(path, output, read_as_binary);
   }
   return internal::DefaultGetResourceContents(path, output, read_as_binary);
 }

--- a/mediapipe/util/resource_util_custom.h
+++ b/mediapipe/util/resource_util_custom.h
@@ -7,7 +7,7 @@
 
 namespace mediapipe {
 
-typedef std::function<absl::Status(const std::string&, std::string*)>
+typedef std::function<absl::Status(const std::string&, std::string*, bool)>
     ResourceProviderFn;
 
 // Returns true if files are provided via a custom resource provider.


### PR DESCRIPTION
Previously, when defining a custom resource provider, the function callback would not tell you whether or not the contents should be read as binary, despite being important information for reading the data. This change makes that information available in the function callback.