### PR TITLE
Made installation compatible with Ubuntu 22.04 and OpenCV 4 on WSL by…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -326,7 +326,7 @@ http_archive(
 new_local_repository(
     name = "linux_opencv",
     build_file = "@//third_party:opencv_linux.BUILD",
-    path = "/usr",
+    path = "/usr/local",
 )
 
 new_local_repository(

--- a/setup_opencv.sh
+++ b/setup_opencv.sh
@@ -40,7 +40,7 @@ if [ -z "$1" ]
     echo "Installing OpenCV from source"
     if [[ -x "$(command -v apt)" ]]; then
       sudo apt update && sudo apt install build-essential git
-      sudo apt install cmake ffmpeg libavformat-dev libdc1394-22-dev libgtk2.0-dev \
+      sudo apt install cmake ffmpeg libavformat-dev libdc1394-dev libgtk2.0-dev \
                        libjpeg-dev libpng-dev libswscale-dev libtbb2 libtbb-dev \
                        libtiff-dev
     elif [[ -x "$(command -v dnf)" ]]; then

--- a/third_party/opencv_linux.BUILD
+++ b/third_party/opencv_linux.BUILD
@@ -13,29 +13,39 @@ exports_files(["LICENSE"])
 # If you install OpenCV separately, please modify the build rule accordingly.
 cc_library(
     name = "opencv",
-    hdrs = glob([
+    srcs = glob(
+	    [
+		    "lib/libopencv_core.so",
+		    "lib/libopencv_highgui.so",
+		    "lib/libopencv_imgcodecs.so",
+		    "lib/libopencv_imgproc.so",
+		    "lib/libopencv_video.so",
+		    "lib/libopencv_videoio.so",
+	    ],
+    ),
+    hdrs = glob(["include/opencv4/**/*.h*"]),
         # For OpenCV 4.x
         #"include/aarch64-linux-gnu/opencv4/opencv2/cvconfig.h",
         #"include/arm-linux-gnueabihf/opencv4/opencv2/cvconfig.h",
         #"include/x86_64-linux-gnu/opencv4/opencv2/cvconfig.h",
         #"include/opencv4/opencv2/**/*.h*",
-    ]),
-    includes = [
+    includes = ["include/opencv4/",
         # For OpenCV 4.x
         #"include/aarch64-linux-gnu/opencv4/",
         #"include/arm-linux-gnueabihf/opencv4/",
         #"include/x86_64-linux-gnu/opencv4/",
         #"include/opencv4/",
     ],
+    linkstatic = 1,
     linkopts = [
-        "-l:libopencv_core.so",
-        "-l:libopencv_calib3d.so",
-        "-l:libopencv_features2d.so",
-        "-l:libopencv_highgui.so",
-        "-l:libopencv_imgcodecs.so",
-        "-l:libopencv_imgproc.so",
-        "-l:libopencv_video.so",
-        "-l:libopencv_videoio.so",
+        #"-l:libopencv_core.so",
+        #"-l:libopencv_calib3d.so",
+        #"-l:libopencv_features2d.so",
+        #"-l:libopencv_highgui.so",
+        #"-l:libopencv_imgcodecs.so",
+        #"-l:libopencv_imgproc.so",
+        #"-l:libopencv_video.so",
+        #"-l:libopencv_videoio.so",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
… making changes in: setup_opencv.sh (need to update libdc1394-22-dev to libdc1394-dev since the former package is now orphaned), and the suggested changes on the installation for openCV 4 given on the official installation page