### PR TITLE
Add undefined check to 'document' variable in platform_utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mediapipe/provisioning_profile.mobileprovision
 node_modules/
 .configure.bazelrc
 .user.bazelrc
+.idea/

--- a/mediapipe/web/graph_runner/platform_utils.ts
+++ b/mediapipe/web/graph_runner/platform_utils.ts
@@ -32,5 +32,5 @@ export function isIOS() {
     // tslint:disable-next-line:deprecation
   ].includes(navigator.platform)
       // iPad on iOS 13 detection
-      || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+      || (navigator.userAgent.includes('Mac') && (window.document !== undefined && 'ontouchend' in document));
 }


### PR DESCRIPTION
It's possible that `document` is not defined, e.g., when we're operating in a web worker. This PR adds an `undefined` check here and makes `isIOS` return false whenever it's not defined.