### PR TITLE
Fixed iOS hand landmarker connections

### DIFF
--- a/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarker.h
+++ b/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarker.h
@@ -78,6 +78,9 @@ NS_SWIFT_NAME(HandLandmarker)
 /** The array of connections between the landmarks in the palm. */
 @property(class, nonatomic, readonly) NSArray<MPPConnection *> *handPalmConnections;
 
+/** The array of connections between the landmarks in the thumb. */
+@property(class, nonatomic, readonly) NSArray<MPPConnection *> *handThumbConnections;
+
 /** The array of connections between the landmarks in the index finger. */
 @property(class, nonatomic, readonly) NSArray<MPPConnection *> *handIndexFingerConnections;
 

--- a/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarker.mm
+++ b/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarker.mm
@@ -169,6 +169,10 @@ static NSString *const kTaskName = @"handLandmarker";
   return MPPHandPalmConnections;
 }
 
++ (NSArray<MPPConnection *> *)handThumbConnections {
+  return MPPHandThumbConnections;
+}
+
 + (NSArray<MPPConnection *> *)handIndexFingerConnections {
   return MPPHandIndexFingerConnections;
 }

--- a/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarksConnections.h
+++ b/mediapipe/tasks/ios/vision/hand_landmarker/sources/MPPHandLandmarksConnections.h
@@ -44,8 +44,8 @@ NSArray<MPPConnection *> *const MPPHandRingFingerConnections = @[
 ];
 
 NSArray<MPPConnection *> *const MPPHandPinkyConnections = @[
-  [[MPPConnection alloc] initWithStart:16 end:17], [[MPPConnection alloc] initWithStart:17 end:18],
-  [[MPPConnection alloc] initWithStart:18 end:19]
+  [[MPPConnection alloc] initWithStart:17 end:18], [[MPPConnection alloc] initWithStart:18 end:19],
+  [[MPPConnection alloc] initWithStart:19 end:20]
 ];
 
 NSArray<MPPConnection *> *const MPPHandConnections = [[[[[[NSArray


### PR DESCRIPTION
1. Fixed typo in hand pinky connections
2. Added a class property for hand thumb connections