### PR TITLE
Remove bug with converting milliseconds to microseconds twice

### DIFF
--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/core/BaseVisionTaskApi.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/core/BaseVisionTaskApi.java
@@ -118,7 +118,7 @@ public class BaseVisionTaskApi implements AutoCloseable {
               .getPacketCreator()
               .createProto(convertToNormalizedRect(imageProcessingOptions, image)));
     }
-    return processVideoData(inputPackets, timestampMs * MICROSECONDS_PER_MILLISECOND);
+    return processVideoData(inputPackets, timestampMs);
   }
 
   /**
@@ -160,7 +160,7 @@ public class BaseVisionTaskApi implements AutoCloseable {
               .getPacketCreator()
               .createProto(convertToNormalizedRect(imageProcessingOptions, image)));
     }
-    sendLiveStreamData(inputPackets, timestampMs * MICROSECONDS_PER_MILLISECOND);
+    sendLiveStreamData(inputPackets, timestampMs);
   }
 
   /**


### PR DESCRIPTION
This PR Fixes an issue for video and live stream mode where the millisecond timestamp is converted to microseconds twice