### PR TITLE
fix: start graph for the case where the input sourceMode is set to video

### DIFF
--- a/mediapipe/examples/ios/common/CommonViewController.mm
+++ b/mediapipe/examples/ios/common/CommonViewController.mm
@@ -113,7 +113,7 @@ static const char* kVideoQueueLabel = "com.google.mediapipe.example.videoQueue";
       self.videoSource = [[MPPPlayerInputSource alloc] initWithAVAsset:video];
       [self.videoSource setDelegate:self queue:self.videoQueue];
       dispatch_async(self.videoQueue, ^{
-        [self.videoSource start];
+        [self startGraphAndVideo];
       });
       break;
     }
@@ -147,6 +147,18 @@ static const char* kVideoQueueLabel = "com.google.mediapipe.example.videoQueue";
       break;
     }
   }
+}
+
+- (void)startGraphAndVideo {
+    NSError* error;
+    if (![self.mediapipeGraph startWithError:&error]) {
+      NSLog(@"Failed to start graph: %@", error);
+    }
+    else if (![self.mediapipeGraph waitUntilIdleWithError:&error]) {
+      NSLog(@"Failed to complete graph initial run: %@", error);
+    }
+
+    [self.videoSource start];
 }
 
 - (void)startGraphAndCamera {


### PR DESCRIPTION
If the `sourceMode` is set to `MediaPipeDemoSourceVideo`, a crash occurs due to the graph not being initiated. This commit includes a fix for the issue.