### PR TITLE
Added iOS Image Embedder Implementation And Basic Objective C Tests

### DIFF
--- a/mediapipe/tasks/ios/test/vision/image_embedder/BUILD
+++ b/mediapipe/tasks/ios/test/vision/image_embedder/BUILD
@@ -1,0 +1,76 @@
+# Copyright 2024 The MediaPipe Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//mediapipe/framework/tool:ios.bzl",
+    "MPP_TASK_MINIMUM_OS_VERSION",
+)
+load(
+    "@org_tensorflow//tensorflow/lite:special_rules.bzl",
+    "tflite_ios_lab_runner",
+)
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+# Default tags for filtering iOS targets. Targets are restricted to Apple platforms.
+TFL_DEFAULT_TAGS = [
+    "apple",
+]
+
+# Following sanitizer tests are not supported by iOS test targets.
+TFL_DISABLED_SANITIZER_TAGS = [
+    "noasan",
+    "nomsan",
+    "notsan",
+]
+
+objc_library(
+    name = "MPPImageEmbedderObjcTestLibrary",
+    testonly = 1,
+    srcs = ["MPPImageEmbedderTests.mm"],
+    copts = [
+        "-ObjC++",
+        "-std=c++17",
+        "-x objective-c++",
+    ],
+    data = [
+        "//mediapipe/tasks/testdata/vision:test_images",
+        "//mediapipe/tasks/testdata/vision:test_models",
+        "//mediapipe/tasks/testdata/vision:test_protos",
+    ],
+    deps = [
+        "//mediapipe/tasks/ios/common:MPPCommon",
+        "//mediapipe/tasks/ios/test/vision/utils:MPPImageTestUtils",
+        "//mediapipe/tasks/ios/vision/image_embedder:MPPImageEmbedder",
+        "//mediapipe/tasks/ios/vision/image_embedder:MPPImageEmbedderResult",
+    ] + select({
+        "//third_party:opencv_ios_sim_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//third_party:opencv_ios_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//third_party:opencv_ios_x86_64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//conditions:default": ["@ios_opencv//:OpencvFramework"],
+    }),
+)
+
+ios_unit_test(
+    name = "MPPImageEmbedderObjcTest",
+    minimum_os_version = MPP_TASK_MINIMUM_OS_VERSION,
+    runner = tflite_ios_lab_runner("IOS_LATEST"),
+    tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
+    deps = [
+        ":MPPImageEmbedderObjcTestLibrary",
+    ],
+)

--- a/mediapipe/tasks/ios/test/vision/image_embedder/MPPImageEmbedderTests.mm
+++ b/mediapipe/tasks/ios/test/vision/image_embedder/MPPImageEmbedderTests.mm
@@ -1,0 +1,260 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "mediapipe/tasks/ios/common/sources/MPPCommon.h"
+#import "mediapipe/tasks/ios/test/vision/utils/sources/MPPImage+TestUtils.h"
+#import "mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedder.h"
+#import "mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedderResult.h"
+
+#include <iostream>
+#include <vector>
+
+static MPPFileInfo *const kBurgerImageFileInfo = [[MPPFileInfo alloc] initWithName:@"burger"
+                                                                              type:@"jpg"];
+static MPPFileInfo *const kBurgerCroppedImageFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"burger_crop" type:@"jpg"];
+static MPPFileInfo *const kBurgerRotatedImageFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"burger_rotated" type:@"jpg"];
+
+static MPPFileInfo *const kMobileNetEmbedderModelFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"mobilenet_v3_small_100_224_embedder" type:@"tflite"];
+
+static NSString *const kExpectedErrorDomain = @"com.google.mediapipe.tasks";
+
+constexpr double kDoubleDifferenceTolerance = 1e-4;
+constexpr NSInteger kExpectedEmbeddingLength = 1024;
+
+#define AssertEqualErrors(error, expectedError)              \
+  XCTAssertNotNil(error);                                    \
+  XCTAssertEqualObjects(error.domain, expectedError.domain); \
+  XCTAssertEqual(error.code, expectedError.code);            \
+  XCTAssertEqualObjects(error.localizedDescription, expectedError.localizedDescription)
+
+#define AssertImageEmbedderResultHasOneEmbedding(imageEmbedderResult) \
+  XCTAssertNotNil(imageEmbedderResult);                               \
+  XCTAssertNotNil(imageEmbedderResult.embeddingResult);               \
+  \ 
+  XCTAssertEqual(imageEmbedderResult.embeddingResult.embeddings.count, 1);
+
+#define AssertEmbeddingHasCorrectTypeAndDimension(embedding, quantized, expectedLength) \
+  if (quantized) {                                                                      \
+    XCTAssertNil(embedding.floatEmbedding);                                             \
+    XCTAssertNotNil(embedding.quantizedEmbedding);                                      \
+    XCTAssertEqual(embedding.quantizedEmbedding.count, expectedLength);                 \
+  } else {                                                                              \
+    XCTAssertNotNil(embedding.floatEmbedding);                                          \
+    XCTAssertNil(embedding.quantizedEmbedding);                                         \
+    XCTAssertEqual(embedding.floatEmbedding.count, expectedLength);                     \
+  }
+
+@interface MPPImageEmbedderTests : XCTestCase
+@end
+
+@implementation MPPImageEmbedderTests
+
+#pragma mark General Tests
+
+- (void)testCreateImageEmbedderFailsWithMissingModelPath {
+  MPPFileInfo *fileInfo = [[MPPFileInfo alloc] initWithName:@"" type:@""];
+
+  NSError *error = nil;
+  MPPImageEmbedder *imageEmbedder = [[MPPImageEmbedder alloc] initWithModelPath:fileInfo.path
+                                                                          error:&error];
+  XCTAssertNil(imageEmbedder);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey :
+                   @"INVALID_ARGUMENT: ExternalFile must specify at least one of 'file_content', "
+                   @"'file_name', 'file_pointer_meta' or 'file_descriptor_meta'."
+             }];
+  AssertEqualErrors(error, expectedError);
+}
+
+- (void)testEmbedWithNoOptionsSucceeds {
+  MPPImageEmbedder *imageEmbedder =
+      [[MPPImageEmbedder alloc] initWithModelPath:kMobileNetEmbedderModelFileInfo.path error:nil];
+
+  [self assertResultsOfEmbedImageWithFileInfo:kBurgerImageFileInfo
+      isApproximatelyEqualToEmbedImageWithFileInfo:kBurgerCroppedImageFileInfo
+                                usingImageEmbedder:imageEmbedder
+                                       isQuantized:NO
+                                withExpectedLength:kExpectedEmbeddingLength
+                               andCosineSimilarity:0.928711f];
+}
+
+- (void)testEmbedWithQuantizationSucceeds {
+  MPPImageEmbedderOptions *options =
+      [self imageSegmenterOptionsWithModelFileInfo:kMobileNetEmbedderModelFileInfo];
+  options.quantize = YES;
+
+  MPPImageEmbedder *imageEmbedder = [self createImageEmbedderWithOptionsSucceeds:options];
+
+  [self assertResultsOfEmbedImageWithFileInfo:kBurgerImageFileInfo
+      isApproximatelyEqualToEmbedImageWithFileInfo:kBurgerCroppedImageFileInfo
+                                usingImageEmbedder:imageEmbedder
+                                       isQuantized:options.quantize
+                                withExpectedLength:kExpectedEmbeddingLength
+                               andCosineSimilarity:0.92883f];
+}
+
+- (void)testEmbedWithL2NormalizationSucceeds {
+  MPPImageEmbedderOptions *options =
+      [self imageSegmenterOptionsWithModelFileInfo:kMobileNetEmbedderModelFileInfo];
+  options.l2Normalize = YES;
+
+  MPPImageEmbedder *imageEmbedder = [self createImageEmbedderWithOptionsSucceeds:options];
+
+  [self assertResultsOfEmbedImageWithFileInfo:kBurgerImageFileInfo
+      isApproximatelyEqualToEmbedImageWithFileInfo:kBurgerCroppedImageFileInfo
+                                usingImageEmbedder:imageEmbedder
+                                       isQuantized:options.quantize
+                                withExpectedLength:kExpectedEmbeddingLength
+                               andCosineSimilarity:0.928711f];
+}
+
+- (void)testEmbedWithRegionOfInterestSucceeds {
+  MPPImageEmbedder *imageEmbedder =
+      [[MPPImageEmbedder alloc] initWithModelPath:kMobileNetEmbedderModelFileInfo.path error:nil];
+
+  MPPImage *burgerImage = [self assertCreateImageWithFileInfo:kBurgerImageFileInfo];
+  MPPImageEmbedderResult *burgerImageResult =
+      [imageEmbedder embedImage:burgerImage
+               regionOfInterest:CGRectMake(0.0f, 0.0f, 0.833333f, 1.0f)
+                          error:nil];
+
+  MPPImage *burgerCroppedImage = [self assertCreateImageWithFileInfo:kBurgerCroppedImageFileInfo];
+  MPPImageEmbedderResult *burgerCroppedImageResult = [imageEmbedder embedImage:burgerCroppedImage
+                                                                         error:nil];
+
+  [self assertImageEmbedderResult:burgerImageResult
+      isApproximatelyEqualToImageEmbedderResult:burgerCroppedImageResult
+                                    isQuantized:NO
+                             withExpectedLength:kExpectedEmbeddingLength
+                            andCosineSimilarity:0.99992f];
+}
+
+- (void)testEmbedWithOrientationSucceeds {
+  MPPImageEmbedder *imageEmbedder =
+      [[MPPImageEmbedder alloc] initWithModelPath:kMobileNetEmbedderModelFileInfo.path error:nil];
+
+  MPPImage *burgerRotatedImage = [self assertCreateImageWithFileInfo:kBurgerRotatedImageFileInfo
+                                                         orientation:UIImageOrientationLeft];
+  MPPImageEmbedderResult *burgerRotatedImageResult = [imageEmbedder embedImage:burgerRotatedImage
+                                                                         error:nil];
+
+  MPPImage *burgerImage = [self assertCreateImageWithFileInfo:kBurgerImageFileInfo];
+  MPPImageEmbedderResult *burgerImageResult = [imageEmbedder embedImage:burgerImage error:nil];
+
+  [self assertImageEmbedderResult:burgerRotatedImageResult
+      isApproximatelyEqualToImageEmbedderResult:burgerImageResult
+                                    isQuantized:NO
+                             withExpectedLength:kExpectedEmbeddingLength
+                            andCosineSimilarity:0.98086f];
+}
+
+#pragma mark - Image Embedder Initializers
+
+- (MPPImageEmbedderOptions *)imageSegmenterOptionsWithModelFileInfo:(MPPFileInfo *)fileInfo {
+  MPPImageEmbedderOptions *options = [[MPPImageEmbedderOptions alloc] init];
+  options.baseOptions.modelAssetPath = fileInfo.path;
+  return options;
+}
+
+- (MPPImageEmbedder *)createImageEmbedderWithOptionsSucceeds:(MPPImageEmbedderOptions *)options {
+  NSError *error;
+  MPPImageEmbedder *imageEmbedder = [[MPPImageEmbedder alloc] initWithOptions:options error:&error];
+  XCTAssertNotNil(imageEmbedder);
+  XCTAssertNil(error);
+
+  return imageEmbedder;
+}
+
+- (void)assertCreateImageEmbedderWithOptions:(MPPImageEmbedderOptions *)options
+                      failsWithExpectedError:(NSError *)expectedError {
+  NSError *error = nil;
+  MPPImageEmbedder *imageSegmenter = [[MPPImageEmbedder alloc] initWithOptions:options
+                                                                         error:&error];
+
+  XCTAssertNil(imageSegmenter);
+  AssertEqualErrors(error, expectedError);
+}
+
+#pragma mark MPPImage Helpers
+
+- (MPPImage *)assertCreateImageWithFileInfo:(MPPFileInfo *)imageFileInfo {
+  MPPImage *image = [MPPImage imageWithFileInfo:imageFileInfo];
+  XCTAssertNotNil(image);
+
+  return image;
+}
+
+- (MPPImage *)assertCreateImageWithFileInfo:(MPPFileInfo *)imageFileInfo
+                                orientation:(UIImageOrientation)orientation {
+  MPPImage *image = [MPPImage imageWithFileInfo:imageFileInfo orientation:orientation];
+  XCTAssertNotNil(image);
+
+  return image;
+}
+
+#pragma mark Assert Embedder Results
+- (void)assertResultsOfEmbedImageWithFileInfo:(MPPFileInfo *)firstImageFileInfo
+    isApproximatelyEqualToEmbedImageWithFileInfo:(MPPFileInfo *)secondImageFileInfo
+                              usingImageEmbedder:(MPPImageEmbedder *)imageEmbedder
+                                     isQuantized:(BOOL)isQuantized
+                              withExpectedLength:(NSInteger)expectedLength
+                             andCosineSimilarity:(double)expectedCosineSimilarity {
+  MPPImage *firstImage = [self assertCreateImageWithFileInfo:firstImageFileInfo];
+  MPPImageEmbedderResult *firstEmbedderResult = [imageEmbedder embedImage:firstImage error:nil];
+
+  MPPImage *secondImage = [self assertCreateImageWithFileInfo:secondImageFileInfo];
+  MPPImageEmbedderResult *secondEmbedderResult = [imageEmbedder embedImage:secondImage error:nil];
+
+  [self assertImageEmbedderResult:firstEmbedderResult
+      isApproximatelyEqualToImageEmbedderResult:secondEmbedderResult
+                                    isQuantized:isQuantized
+                             withExpectedLength:expectedLength
+                            andCosineSimilarity:expectedCosineSimilarity];
+}
+
+- (void)assertImageEmbedderResult:(MPPImageEmbedderResult *)firstImageEmbedderResult
+    isApproximatelyEqualToImageEmbedderResult:(MPPImageEmbedderResult *)secondImageEmbedderResult
+                                  isQuantized:(BOOL)isQuantized
+                           withExpectedLength:(NSInteger)expectedLength
+                          andCosineSimilarity:(double)expectedCosineSimilarity {
+  AssertImageEmbedderResultHasOneEmbedding(firstImageEmbedderResult);
+  AssertEmbeddingHasCorrectTypeAndDimension(firstImageEmbedderResult.embeddingResult.embeddings[0],
+                                            isQuantized, expectedLength);
+
+  AssertImageEmbedderResultHasOneEmbedding(secondImageEmbedderResult);
+  AssertEmbeddingHasCorrectTypeAndDimension(secondImageEmbedderResult.embeddingResult.embeddings[0],
+                                            isQuantized, expectedLength);
+
+  NSNumber *cosineSimilarity = [MPPImageEmbedder
+      cosineSimilarityBetweenEmbedding1:firstImageEmbedderResult.embeddingResult.embeddings[0]
+                          andEmbedding2:secondImageEmbedderResult.embeddingResult.embeddings[0]
+                                  error:nil];
+
+  XCTAssertNotNil(cosineSimilarity);
+
+  XCTAssertEqualWithAccuracy(cosineSimilarity.doubleValue, expectedCosineSimilarity,
+                             kDoubleDifferenceTolerance);
+}
+
+@end

--- a/mediapipe/tasks/ios/vision/image_embedder/BUILD
+++ b/mediapipe/tasks/ios/vision/image_embedder/BUILD
@@ -39,6 +39,7 @@ objc_library(
 
 objc_library(
     name = "MPPImageEmbedder",
+    srcs = ["sources/MPPImageEmbedder.mm"],
     hdrs = ["sources/MPPImageEmbedder.h"],
     copts = [
         "-ObjC++",
@@ -49,6 +50,15 @@ objc_library(
     deps = [
         ":MPPImageEmbedderOptions",
         ":MPPImageEmbedderResult",
+        "//mediapipe/tasks/cc/vision/image_embedder:image_embedder_graph",
+        "//mediapipe/tasks/ios/common/utils:MPPCommonUtils",
+        "//mediapipe/tasks/ios/common/utils:NSStringHelpers",
+        "//mediapipe/tasks/ios/components/utils:MPPCosineSimilarity",
+        "//mediapipe/tasks/ios/core:MPPTaskInfo",
         "//mediapipe/tasks/ios/vision/core:MPPImage",
+        "//mediapipe/tasks/ios/vision/core:MPPVisionPacketCreator",
+        "//mediapipe/tasks/ios/vision/core:MPPVisionTaskRunner",
+        "//mediapipe/tasks/ios/vision/image_embedder/utils:MPPImageEmbedderOptionsHelpers",
+        "//mediapipe/tasks/ios/vision/image_embedder/utils:MPPImageEmbedderResultHelpers",
     ],
 )

--- a/mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedder.mm
+++ b/mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedder.mm
@@ -1,0 +1,244 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedder.h"
+
+#import "mediapipe/tasks/ios/common/utils/sources/MPPCommonUtils.h"
+#import "mediapipe/tasks/ios/common/utils/sources/NSString+Helpers.h"
+#import "mediapipe/tasks/ios/components/utils/sources/MPPCosineSimilarity.h"
+#import "mediapipe/tasks/ios/core/sources/MPPTaskInfo.h"
+#import "mediapipe/tasks/ios/vision/core/sources/MPPVisionPacketCreator.h"
+#import "mediapipe/tasks/ios/vision/core/sources/MPPVisionTaskRunner.h"
+#import "mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderOptions+Helpers.h"
+#import "mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderResult+Helpers.h"
+
+namespace {
+using ::mediapipe::NormalizedRect;
+using ::mediapipe::Packet;
+using ::mediapipe::Timestamp;
+using ::mediapipe::tasks::core::PacketMap;
+using ::mediapipe::tasks::core::PacketsCallback;
+}  // namespace
+
+static NSString *const kEmbeddingsOutStreamName = @"embeddings_out";
+static NSString *const kEmbeddingsTag = @"EMBEDDINGS";
+static NSString *const kImageInStreamName = @"image_in";
+static NSString *const kImageOutStreamName = @"image_out";
+static NSString *const kImageTag = @"IMAGE";
+static NSString *const kNormRectStreamName = @"norm_rect_in";
+static NSString *const kNormRectTag = @"NORM_RECT";
+static NSString *const kTaskGraphName = @"mediapipe.tasks.vision.image_embedder.ImageEmbedderGraph";
+static NSString *const kTaskName = @"imageEmbedder";
+
+static const int kMicrosecondsPerMillisecond = 1000;
+
+#define InputPacketMap(imagePacket, normalizedRectPacket) \
+  {                                                       \
+    {kImageInStreamName.cppString, imagePacket}, {        \
+      kNormRectStreamName.cppString, normalizedRectPacket \
+    }                                                     \
+  }
+
+#define ImageEmbedderResultWithOutputPacketMap(outputPacketMap)                             \
+  ([MPPImageEmbedderResult                                                                  \
+      imageEmbedderResultWithEmbeddingResultPacket:outputPacketMap[kEmbeddingsOutStreamName \
+                                                                       .cppString]])
+
+@interface MPPImageEmbedder () {
+  /** iOS Vision Task Runner */
+  MPPVisionTaskRunner *_visionTaskRunner;
+  dispatch_queue_t _callbackQueue;
+}
+@property(nonatomic, weak) id<MPPImageEmbedderLiveStreamDelegate> imageEmbedderLiveStreamDelegate;
+@end
+
+@implementation MPPImageEmbedder
+
+#pragma mark - Public
+
+- (instancetype)initWithOptions:(MPPImageEmbedderOptions *)options error:(NSError **)error {
+  self = [super init];
+  if (self) {
+    MPPTaskInfo *taskInfo = [[MPPTaskInfo alloc]
+        initWithTaskGraphName:kTaskGraphName
+                 inputStreams:@[
+                   [NSString stringWithFormat:@"%@:%@", kImageTag, kImageInStreamName],
+                   [NSString stringWithFormat:@"%@:%@", kNormRectTag, kNormRectStreamName]
+                 ]
+                outputStreams:@[
+                  [NSString stringWithFormat:@"%@:%@", kEmbeddingsTag, kEmbeddingsOutStreamName],
+                  [NSString stringWithFormat:@"%@:%@", kImageTag, kImageOutStreamName]
+                ]
+                  taskOptions:options
+           enableFlowLimiting:options.runningMode == MPPRunningModeLiveStream
+                        error:error];
+
+    if (!taskInfo) {
+      return nil;
+    }
+
+    PacketsCallback packetsCallback = nullptr;
+
+    if (options.imageEmbedderLiveStreamDelegate) {
+      _imageEmbedderLiveStreamDelegate = options.imageEmbedderLiveStreamDelegate;
+
+      // Create a private serial dispatch queue in which the deleagte method will be called
+      // asynchronously. This is to ensure that if the client performs a long running operation in
+      // the delegate method, the queue on which the C++ callbacks is invoked is not blocked and is
+      // freed up to continue with its operations.
+      _callbackQueue = dispatch_queue_create(
+          [MPPVisionTaskRunner uniqueDispatchQueueNameWithSuffix:kTaskName], NULL);
+
+      // Capturing `self` as weak in order to avoid `self` being kept in memory
+      // and cause a retain cycle, after self is set to `nil`.
+      MPPImageEmbedder *__weak weakSelf = self;
+      packetsCallback = [=](absl::StatusOr<PacketMap> liveStreamResult) {
+        [weakSelf processLiveStreamResult:liveStreamResult];
+      };
+    }
+
+    _visionTaskRunner = [[MPPVisionTaskRunner alloc] initWithTaskInfo:taskInfo
+                                                          runningMode:options.runningMode
+                                                           roiAllowed:YES
+                                                      packetsCallback:std::move(packetsCallback)
+                                                 imageInputStreamName:kImageInStreamName
+                                              normRectInputStreamName:kNormRectStreamName
+                                                                error:error];
+
+    if (!_visionTaskRunner) {
+      return nil;
+    }
+  }
+  return self;
+}
+
+- (instancetype)initWithModelPath:(NSString *)modelPath error:(NSError **)error {
+  MPPImageEmbedderOptions *options = [[MPPImageEmbedderOptions alloc] init];
+
+  options.baseOptions.modelAssetPath = modelPath;
+
+  return [self initWithOptions:options error:error];
+}
+
+- (nullable MPPImageEmbedderResult *)embedImage:(MPPImage *)image
+                               regionOfInterest:(CGRect)roi
+                                          error:(NSError **)error {
+  std::optional<PacketMap> outputPacketMap = [_visionTaskRunner processImage:image
+                                                            regionOfInterest:roi
+                                                                       error:error];
+
+  return [MPPImageEmbedder imageEmbedderResultWithOptionalOutputPacketMap:outputPacketMap];
+}
+
+- (nullable MPPImageEmbedderResult *)embedImage:(MPPImage *)image error:(NSError **)error {
+  return [self embedImage:image regionOfInterest:CGRectZero error:error];
+}
+
+- (nullable MPPImageEmbedderResult *)embedVideoFrame:(MPPImage *)image
+                             timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                                    regionOfInterest:(CGRect)roi
+                                               error:(NSError **)error {
+  std::optional<PacketMap> outputPacketMap =
+      [_visionTaskRunner processVideoFrame:image
+                          regionOfInterest:roi
+                   timestampInMilliseconds:timestampInMilliseconds
+                                     error:error];
+
+  return [MPPImageEmbedder imageEmbedderResultWithOptionalOutputPacketMap:outputPacketMap];
+}
+
+- (nullable MPPImageEmbedderResult *)embedVideoFrame:(MPPImage *)image
+                             timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                                               error:(NSError **)error {
+  return [self embedVideoFrame:image
+       timestampInMilliseconds:timestampInMilliseconds
+              regionOfInterest:CGRectZero
+                         error:error];
+}
+
+- (BOOL)embedAsyncImage:(MPPImage *)image
+    timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+           regionOfInterest:(CGRect)roi
+                      error:(NSError **)error {
+  return [_visionTaskRunner processLiveStreamImage:image
+                                  regionOfInterest:roi
+                           timestampInMilliseconds:timestampInMilliseconds
+                                             error:error];
+}
+
+- (BOOL)embedAsyncImage:(MPPImage *)image
+    timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                      error:(NSError **)error {
+  return [self embedAsyncImage:image
+       timestampInMilliseconds:timestampInMilliseconds
+              regionOfInterest:CGRectZero
+                         error:error];
+}
+
++ (nullable NSNumber *)cosineSimilarityBetweenEmbedding1:(MPPEmbedding *)embedding1
+                                           andEmbedding2:(MPPEmbedding *)embedding2
+                                                   error:(NSError **)error {
+  return [MPPCosineSimilarity computeBetweenEmbedding1:embedding1
+                                         andEmbedding2:embedding2
+                                                 error:error];
+}
+
+#pragma mark - Private
+
+- (void)processLiveStreamResult:(absl::StatusOr<PacketMap>)liveStreamResult {
+  if (![self.imageEmbedderLiveStreamDelegate
+          respondsToSelector:@selector(imageEmbedder:
+                                 didFinishEmbeddingWithResult:timestampInMilliseconds:error:)]) {
+    return;
+  }
+
+  NSError *callbackError = nil;
+  if (![MPPCommonUtils checkCppError:liveStreamResult.status() toError:&callbackError]) {
+    dispatch_async(_callbackQueue, ^{
+      [self.imageEmbedderLiveStreamDelegate imageEmbedder:self
+                             didFinishEmbeddingWithResult:nil
+                                  timestampInMilliseconds:Timestamp::Unset().Value()
+                                                    error:callbackError];
+    });
+    return;
+  }
+
+  PacketMap &outputPacketMap = liveStreamResult.value();
+  if (outputPacketMap[kImageOutStreamName.cppString].IsEmpty()) {
+    return;
+  }
+
+  MPPImageEmbedderResult *result = ImageEmbedderResultWithOutputPacketMap(outputPacketMap);
+
+  NSInteger timestampInMilliseconds =
+      outputPacketMap[kImageOutStreamName.cppString].Timestamp().Value() /
+      kMicrosecondsPerMillisecond;
+  dispatch_async(_callbackQueue, ^{
+    [self.imageEmbedderLiveStreamDelegate imageEmbedder:self
+                           didFinishEmbeddingWithResult:result
+                                timestampInMilliseconds:timestampInMilliseconds
+                                                  error:callbackError];
+  });
+}
+
++ (nullable MPPImageEmbedderResult *)imageEmbedderResultWithOptionalOutputPacketMap:
+    (std::optional<PacketMap>)outputPacketMap {
+  if (!outputPacketMap.has_value()) {
+    return nil;
+  }
+
+  return ImageEmbedderResultWithOutputPacketMap(outputPacketMap.value());
+}
+
+@end

--- a/mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedderResult.h
+++ b/mediapipe/tasks/ios/vision/image_embedder/sources/MPPImageEmbedderResult.h
@@ -36,7 +36,7 @@ NS_SWIFT_NAME(ImageEmbedderResult)
  * @return An instance of `ImageEmbedderResult` initialized with the given
  * `MPPEmbeddingResult` and timestamp (in milliseconds).
  */
-- (instancetype)initWithEmbeddingResult:(MPPEmbeddingResult *)embeddingResult
+- (instancetype)initWithEmbeddingResult:(nullable MPPEmbeddingResult *)embeddingResult
                 timestampInMilliseconds:(NSInteger)timestampInMilliseconds;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderResult+Helpers.h
+++ b/mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderResult+Helpers.h
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MPPImageEmbedderResult (Helpers)
 
-+ (MPPImageEmbedderResult *)imageEmbedderResultWithOutputPacket:(const mediapipe::Packet &)packet;
++ (MPPImageEmbedderResult *)imageEmbedderResultWithEmbeddingResultPacket:
+    (const mediapipe::Packet &)packet;
 
 @end
 

--- a/mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderResult+Helpers.mm
+++ b/mediapipe/tasks/ios/vision/image_embedder/utils/sources/MPPImageEmbedderResult+Helpers.mm
@@ -28,7 +28,13 @@ using ::mediapipe::Packet;
 
 @implementation MPPImageEmbedderResult (Helpers)
 
-+ (MPPImageEmbedderResult *)imageEmbedderResultWithOutputPacket:(const Packet &)packet {
++ (MPPImageEmbedderResult *)imageEmbedderResultWithEmbeddingResultPacket:(const Packet &)packet {
+  if (!packet.ValidateAsType<EmbeddingResultProto>().ok()) {
+    // MPPImageEmbedderResult's timestamp is populated from timestamp `EmbeddingResultProto`'s
+    // timestamp_ms(). It is 0 since the packet can't be validated as a `EmbeddingResultProto`.
+    return [[MPPImageEmbedderResult alloc] initWithEmbeddingResult:nil timestampInMilliseconds:0];
+  }
+
   MPPEmbeddingResult *embeddingResult =
       [MPPEmbeddingResult embeddingResultWithProto:packet.Get<EmbeddingResultProto>()];
 


### PR DESCRIPTION
1. Added MPPImageEmbedder.mm
2. Added packet validation in MPPImageEmbedderResult+Helpers
3. Updated method signature of MPPImageEmbedderResult Initializer
4. Added basic Objective C tests for MPPImageEmbedder