### PR TITLE
Added deletion of cache files and updated interface of iOS LlmTaskRunner and LlmInference

### DIFF
--- a/mediapipe/tasks/cc/genai/inference/c/BUILD
+++ b/mediapipe/tasks/cc/genai/inference/c/BUILD
@@ -21,7 +21,7 @@ cc_library(
     name = "libllm_inference_engine_cpu",
     srcs = ["llm_inference_engine_cpu.cc"],
     hdrs = ["llm_inference_engine.h"],
-    tags = ["swift_module=LlmInferenceEngineC"],
+    tags = ["swift_module=MediaPipeTasksGenAIC"],
     deps = [
         "//mediapipe/framework/port:file_helpers",
         "//mediapipe/framework/port:ret_check",

--- a/mediapipe/tasks/ios/BUILD
+++ b/mediapipe/tasks/ios/BUILD
@@ -91,6 +91,7 @@ MEDIAPIPE_TASKS_COMMON_DEPS = OBJC_TASK_COMMON_DEPS + TENSORFLOW_LITE_C_DEPS + [
 strip_api_include_path_prefix(
     name = "strip_api_include_path",
     hdr_labels = [
+        "//mediapipe/tasks/cc/genai/inference/c:llm_inference_engine.h",
         "//mediapipe/tasks/ios/common:sources/MPPCommon.h",
         "//mediapipe/tasks/ios/components/containers:sources/MPPCategory.h",
         "//mediapipe/tasks/ios/components/containers:sources/MPPClassificationResult.h",
@@ -320,4 +321,45 @@ apple_static_xcframework(
     # when installed alongside the respective frameworks since task graphs are
     # built as static libraries and force loaded.
     deps = MEDIAPIPE_TASKS_COMMON_DEPS + select(OPENCV_DEPS),
+)
+
+apple_static_xcframework(
+    name = "MediaPipeTasksGenAI_framework",
+    avoid_deps = ["//mediapipe/tasks/cc/genai/inference/c:libllm_inference_engine_cpu",],
+    bundle_name = "MediaPipeTasksGenAI",
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": MPP_TASK_MINIMUM_OS_VERSION,
+    },
+    deps = [
+        "//mediapipe/tasks/ios/genai/inference:LlmInference",
+        "//mediapipe/tasks/cc/genai/inference/c:libllm_inference_engine_cpu",
+    ],
+)
+
+apple_static_xcframework(
+    name = "MediaPipeTasksGenAIC_framework",
+    bundle_name = "MediaPipeTasksGenAIC",
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": MPP_TASK_MINIMUM_OS_VERSION,
+    },
+    public_hdrs = [
+        ":llm_inference_engine.h",
+    ],
+    deps = [
+        "//mediapipe/tasks/cc/genai/inference/c:libllm_inference_engine_cpu",
+    ],
 )

--- a/mediapipe/tasks/ios/build_ios_framework.sh
+++ b/mediapipe/tasks/ios/build_ios_framework.sh
@@ -56,8 +56,12 @@ case $FRAMEWORK_NAME in
     ;;
   "MediaPipeTasksText")
     ;;
+  "MediaPipeTasksGenAIC")
+    ;;
+  "MediaPipeTasksGenAI")
+    ;;
   *)
-    echo "Wrong framework name. The following framework names are allowed: MediaPipeTasksText, MediaPipeTasksVision, MediaPipeTasksCommon"
+    echo "Wrong framework name. The following framework names are allowed: MediaPipeTasksText, MediaPipeTasksVision, MediaPipeTasksCommon, MediaPipeTasksGenAI, MediaPipeTasksGenAIC"
     exit 1
   ;;
 esac
@@ -90,7 +94,6 @@ EOF
 function build_ios_frameworks_and_libraries {
   local TARGET_PREFIX="//mediapipe/tasks/ios"
   FULL_FRAMEWORK_TARGET="${TARGET_PREFIX}:${FRAMEWORK_NAME}_framework"
-  FULL_GRAPH_LIBRARY_TARGET="${TARGET_PREFIX}:${FRAMEWORK_NAME}_GraphLibrary"
 
   # .bazelrc sets --apple_generate_dsym=true by default which bloats the libraries to sizes of
   # the order of GBs. All iOS framework and library build commands for distribution via
@@ -99,6 +102,15 @@ function build_ios_frameworks_and_libraries {
 
   # Build Task Library xcframework.
   local FRAMEWORK_CQUERY_COMMAND="-c opt --config=ios_sim_device_fat --apple_generate_dsym=false --define OPENCV=source ${FULL_FRAMEWORK_TARGET}"
+  
+  case $FRAMEWORK_NAME in
+    "MediaPipeTasksGenAI|MediaPipeTasksGenAIC")
+      FRAMEWORK_CQUERY_COMMAND="c opt --config=ios_sim_device_fat --apple_generate_dsym=false ${FULL_FRAMEWORK_TARGET}"
+      ;;
+    *)
+    ;;
+  esac
+
   ${BAZEL} build ${FRAMEWORK_CQUERY_COMMAND}
   IOS_FRAMEWORK_PATH="$(get_output_file_path "${FRAMEWORK_CQUERY_COMMAND}")"
 

--- a/mediapipe/tasks/ios/genai/core/BUILD
+++ b/mediapipe/tasks/ios/genai/core/BUILD
@@ -12,20 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-
 licenses(["notice"])
 
 package(default_visibility = ["//mediapipe/tasks:internal"])
 
-swift_library(
-    name = "LlmTaskRunner",
-    srcs = [
-        "sources/GenAiInferenceError.swift",
-        "sources/LlmTaskRunner.swift",
-    ],
-    module_name = "LlmTaskRunner",
-    deps = [
-        "//mediapipe/tasks/cc/genai/inference/c:libllm_inference_engine_cpu",
-    ],
-)
+exports_files(["sources/LlmTaskRunner.swift", "sources/GenAiInferenceError.swift"])

--- a/mediapipe/tasks/ios/genai/core/sources/GenAiInferenceError.swift
+++ b/mediapipe/tasks/ios/genai/core/sources/GenAiInferenceError.swift
@@ -16,15 +16,22 @@ import Foundation
 
 /// Errors thrown by MediaPipe GenAI Tasks.
 public enum GenAiInferenceError: Error {
-  case invalidResponseError
+  case invalidResponse
+  case illegalMethodCall
+  case modelNotFound
 }
 
 extension GenAiInferenceError: LocalizedError {
   /// A localized description of the `GenAiInferenceError`.
   public var errorDescription: String? {
     switch self {
-    case .invalidResponseError:
+    case .invalidResponse:
       return "The response returned by the model is invalid."
+    case .illegalMethodCall:
+      return
+        "You cannot invoke `generateResponse` while another response generation invocation is in progress."
+    case .modelNotFound:
+      return "No file found at the `modelPath` you provided."
     }
   }
 }
@@ -37,8 +44,12 @@ extension GenAiInferenceError: CustomNSError {
 
   public var errorCode: Int {
     switch self {
-    case .invalidResponseError:
+    case .invalidResponse:
       return 0
+    case .illegalMethodCall:
+      return 1
+    case .modelNotFound:
+      return 2
     }
   }
 }

--- a/mediapipe/tasks/ios/genai/core/sources/LlmTaskRunner.swift
+++ b/mediapipe/tasks/ios/genai/core/sources/LlmTaskRunner.swift
@@ -13,24 +13,65 @@
 // limitations under the License.
 
 import Foundation
-import LlmInferenceEngineC
+import MediaPipeTasksGenAIC
 
 /// This class is used to create and call appropriate methods on the C `LlmInferenceEngine_Session`
 /// to initialize, execute and terminate any MediaPipe `LlmInference` task.
-public final class LlmTaskRunner {
-  fileprivate typealias CLlmSession = UnsafeMutableRawPointer
+/// Note: Tasks should not attempt to clear undeleted caches on initialization since user can create
+/// multiple instances of the task and there is now way of knowing whether they are still
+/// active. Deleting caches of active task instances will result in crashes when the C++
+/// functions are invoked.
+/// Instead tasks can encapsulate `clearAllCachedFiles()` to provide a function to delete
+/// any undeleted caches when the user wishes to.
+final class LlmTaskRunner {
+  private typealias CLlmSession = UnsafeMutableRawPointer
+
+  private static let cacheSuffix = ".cache"
+  private static let globalCacheDirectory = FileManager.default.temporaryDirectory
+    .versionIndependentAppending(component: "mediapipe.genai.inference.cache")
+  private static let cacheDirectory = LlmTaskRunner.globalCacheDirectory
+    .versionIndependentAppending(component: "\(UUID().uuidString)")
 
   private let cLlmSession: CLlmSession
 
+  private let modelCacheFile: URL
   /// Creates a new instance of `LlmTaskRunner` with the given session config.
   ///
   /// - Parameters:
   ///   - sessionConfig: C session config of type `LlmSessionConfig`.
-  public init(sessionConfig: LlmSessionConfig) {
-    /// No safe guards for session creation since the C APIs only throw fatal errors.
-    /// `LlmInferenceEngine_CreateSession()` will always return an llm session if the call
+  init(config: Config) throws {
+    guard FileManager.default.fileExists(atPath: config.modelPath),
+      let modelName = config.modelPath.components(separatedBy: "/").last
+    else {
+      throw GenAiInferenceError.modelNotFound
+    }
+
+    /// Adding a `UUID` prefix to the cache path to prevent the app from crashing if a model cache
+    /// is already found in the temporary directory.
+    /// Cache will be deleted when the task runner is de-allocated. Preferring deletion on
+    /// de-allocation to deleting all caches on initialization to prevent model caches of
+    /// other task runners from being de-allocated prematurely during their life time.
+    ///
+    /// Note: No safe guards for session creation since the C APIs only throw fatal errors.
+    /// `LlmInferenceEngine_CreateSession()` will always return a llm session if the call
     /// completes.
-    self.cLlmSession = withUnsafePointer(to: sessionConfig) { LlmInferenceEngine_CreateSession($0) }
+    cLlmSession = LlmTaskRunner.cacheDirectory.path.withCString { cCacheDir in
+      return config.modelPath.withCString { cModelPath in
+        let cSessionConfig = LlmSessionConfig(
+          model_path: cModelPath,
+          cache_dir: cCacheDir,
+          sequence_batch_size: Int(config.sequenceBatchSize),
+          num_decode_steps_per_sync: Int(config.numberOfDecodeStepsPerSync),
+          max_tokens: Int(config.maxTokens),
+          topk: Int(config.topk),
+          temperature: config.temperature,
+          random_seed: config.randomSeed)
+        return withUnsafePointer(to: cSessionConfig) { LlmInferenceEngine_CreateSession($0) }
+      }
+    }
+
+    modelCacheFile = LlmTaskRunner.cacheDirectory.versionIndependentAppending(
+      component: "\(modelName)\(LlmTaskRunner.cacheSuffix)")
   }
 
   /// Invokes the C inference engine with the given input text to generate an array of `String`
@@ -39,7 +80,7 @@ public final class LlmTaskRunner {
   /// - Parameters:
   ///   - inputText: A `String` that is used to query the LLM.
   /// - Throws: An error if the LLM's response is invalid.
-  public func predict(inputText: String) throws -> [String] {
+  func predict(inputText: String) throws -> [String] {
     /// No safe guards for the call since the C++ APIs only throw fatal errors.
     /// `LlmInferenceEngine_Session_PredictSync()` will always return a `LlmResponseContext` if the
     /// call completes.
@@ -53,25 +94,195 @@ public final class LlmTaskRunner {
       }
     }
 
-    /// Throw an error if the response array is `NULL`.
+    guard let responseStrings = LlmTaskRunner.responseStrings(from: responseContext) else {
+      throw GenAiInferenceError.invalidResponse
+    }
+
+    return responseStrings
+  }
+
+  func predict(
+    inputText: String, progress: @escaping (_ partialResult: [String]?, _ error: Error?) -> Void,
+    completion: @escaping (() -> Void)
+  ) {
+
+    /// `strdup(inputText)` prevents input text from being deallocated as long as callbacks are
+    /// being invoked. `CallbackInfo` takes care of freeing the memory of `inputText` when it is
+    /// deallocated.
+    let callbackInfo = CallbackInfo(
+      inputText: strdup(inputText), progress: progress, completion: completion)
+    let callbackContext = UnsafeMutableRawPointer(Unmanaged.passRetained(callbackInfo).toOpaque())
+
+    LlmInferenceEngine_Session_PredictAsync(cLlmSession, callbackContext, callbackInfo.inputText) {
+      context, responseContext in
+      guard let cContext = context else {
+        return
+      }
+
+      /// `takeRetainedValue()` decrements the reference count incremented by `passRetained()`. Only
+      /// take a retained value if the LLM has finished generating responses to prevent the context
+      /// from being deallocated in between response generation.
+      let cCallbackInfo =
+        responseContext.done
+        ? Unmanaged<CallbackInfo>.fromOpaque(cContext).takeRetainedValue()
+        : Unmanaged<CallbackInfo>.fromOpaque(cContext).takeUnretainedValue()
+
+      if let responseStrings = LlmTaskRunner.responseStrings(from: responseContext) {
+        cCallbackInfo.progress(responseStrings, nil)
+      } else {
+        cCallbackInfo.progress(nil, GenAiInferenceError.invalidResponse)
+      }
+
+      /// Call completion callback if LLM has generated its last response.
+      if responseContext.done {
+        cCallbackInfo.completion()
+      }
+    }
+  }
+
+  /// Clears all cached files created by `LlmInference` to prevent exponential growth of your app
+  /// size. Please ensure that this method is not called during the lifetime of any instances of
+  /// `LlmTaskRunner`.
+  static func clearAllCachedFiles() throws {
+    // Delete directory
+    try FileManager.default.removeItem(at: LlmTaskRunner.globalCacheDirectory)
+  }
+
+  deinit {
+    LlmInferenceEngine_Session_Delete(cLlmSession)
+
+    /// Responsibly deleting the model cache.
+    /// Performing on current thread since only one file needs to be deleted.
+    ///
+    /// Note: Implementation will have to be updated if C++ core changes the cache prefix.
+    ///
+    /// Note: `deinit` does not get invoked in the following circumstances:
+    /// 1. If a crash occurs before the task runner is de-allocated.
+    /// 2. If an instance of the task is created from `main()` and the app is terminated.
+    ///    For eg:, if the task is an instance variable of the main `ViewController` which doesn't
+    ///    get destroyed until the app quits.
+    /// Task interfaces that use the task runner should additionally provide a function that
+    /// encapsulates `LlmTaskrRunner.clearAllCachedFiles()` to cleanup any undeleted caches to
+    /// avoid exponential growth in app size. OS clears these directories only if the device runs
+    /// out of storage space.
+    /// Tasks should not attempt to clear undeleted caches on initialization since user can create
+    /// multiple instances of the task and there is now way of knowing whether they are still
+    /// active. Deleting caches of active task instances will result in crashes when the C++
+    /// functions are invoked.
+    do {
+      try FileManager.default.removeItem(at: modelCacheFile)
+    } catch {
+      // Could not delete file. Common cause: file not found.
+    }
+  }
+}
+
+extension LlmTaskRunner {
+  /// Configuration for setting up a `LlmTaskRunner`.
+  struct Config {
+    /// The absolute path to the model asset bundle stored locally on the device.
+    let modelPath: String
+
+    let sequenceBatchSize: UInt
+
+    let numberOfDecodeStepsPerSync: UInt
+
+    /// The total length of the kv-cache. In other words, this is the total number of input + output
+    /// tokens the model needs to handle.
+    let maxTokens: UInt
+
+    /// The top K number of tokens to be sampled from for each decoding step. A value of 1 means
+    /// greedy decoding. Defaults to 40.
+    let topk: UInt
+
+    /// The randomness when decoding the next token. A value of 0.0f means greedy decoding. Defaults
+    /// to 0.8.
+    let temperature: Float
+
+    /// The random seed for sampling tokens.
+    let randomSeed: Int
+
+    /// Creates a new instance of `Config` with the provided values.
+    ///
+    /// - Parameters:
+    ///   - modelPath: The absolute path to a model asset bundle stored locally on the device.
+    ///   - sequenceBatchSize: Sequence batch size for encoding. Used by GPU only. Number of
+    /// input tokens to process at a time for batch processing. Setting this value to 1 means both
+    /// the encoding and decoding share the same graph of sequence length of 1. Setting this value
+    /// to 0 means the batch size will be optimized
+    /// programmatically.
+    ///   - numberOfDecodeStepsPerSync: Number of decode steps per sync. Used by GPU only.
+    /// The default value is 3.
+    ///   - maxTokens: Maximum number of tokens for input and output.
+    ///   - topk: Top K number of tokens to be sampled from for each decoding step.
+    ///   - temperature: Randomness when decoding the next token, 0.0f means greedy decoding.
+    ///   - random_seed: Random seed for sampling tokens.
+    init(
+      modelPath: String, sequenceBatchSize: UInt, numberOfDecodeStepsPerSync: UInt, maxTokens: UInt,
+      topk: UInt, temperature: Float, randomSeed: Int
+    ) {
+      self.modelPath = modelPath
+      self.sequenceBatchSize = sequenceBatchSize
+      self.numberOfDecodeStepsPerSync = numberOfDecodeStepsPerSync
+      self.maxTokens = maxTokens
+      self.topk = topk
+      self.temperature = temperature
+      self.randomSeed = randomSeed
+    }
+  }
+}
+
+private extension LlmTaskRunner {
+  /// A wrapper class for whose object will be used as the C++ callback context.
+  /// The progress and completion callbacks cannot be invoked without a context.
+  class CallbackInfo {
+    typealias ProgressCallback = (_ partialResult: [String]?, _ error: Error?) -> Void
+    typealias CompletionCallback = () -> Void
+
+    let inputText: UnsafeMutablePointer<CChar>?
+    let progress: ProgressCallback
+    let completion: CompletionCallback
+
+    init(
+      inputText: UnsafeMutablePointer<CChar>?, progress: @escaping (ProgressCallback),
+      completion: @escaping (CompletionCallback)
+    ) {
+      self.inputText = inputText
+      self.progress = progress
+      self.completion = completion
+    }
+
+    deinit {
+      free(inputText)
+    }
+  }
+}
+
+private extension LlmTaskRunner {
+  class func responseStrings(from responseContext: LlmResponseContext) -> [String]? {
     guard let cResponseArray = responseContext.response_array else {
-      throw GenAiInferenceError.invalidResponseError
+      return nil
     }
 
     var responseStrings: [String] = []
-
     for responseIndex in 0..<Int(responseContext.response_count) {
+      /// Throw an error if the response string is `NULL`.
       guard let cResponseString = cResponseArray[responseIndex] else {
-        throw GenAiInferenceError.invalidResponseError
+        return nil
       }
       responseStrings.append(String(cString: cResponseString))
     }
 
     return responseStrings
   }
+}
 
-  deinit {
-    LlmInferenceEngine_Session_Delete(cLlmSession)
+fileprivate extension URL {
+  func versionIndependentAppending(component: String) -> URL {
+    if #available(iOS 16, *) {
+      return self.appending(component: component)
+    } else {
+      return self.appendingPathComponent(component)
+    }
   }
-
 }

--- a/mediapipe/tasks/ios/genai/inference/BUILD
+++ b/mediapipe/tasks/ios/genai/inference/BUILD
@@ -22,9 +22,12 @@ swift_library(
     name = "LlmInference",
     srcs = [
         "sources/LlmInference.swift",
+        "//mediapipe/tasks/ios/genai/core:sources/LlmTaskRunner.swift",
+        "//mediapipe/tasks/ios/genai/core:sources/GenAiInferenceError.swift",
     ],
+    copts = ["-no-verify-emitted-module-interface"],
+    module_name = "MediaPipeTasksGenAI",
     generated_header_name = "LlmInference-Swift.h",
     generates_header = 1,
-    module_name = "LlmInference",
-    deps = ["//mediapipe/tasks/ios/genai/core:LlmTaskRunner"],
+    deps = ["//mediapipe/tasks/cc/genai/inference/c:libllm_inference_engine_cpu",],
 )


### PR DESCRIPTION
1. Moved caching logic to LlmTaskRunner
2. Added method to interface of LlmInference for deleting all caches.
3. Updated property types in LlmInference.Options
4. Added an extra check to see if provided modelPath is valid. As a result updated LlmInference and LlmTaskRunner inits to be throwing methods.
5. Updated access modifiers of some classes.