### PR TITLE
Added iOS Holistic Landmarker Objective C Tests and Updated Types in Holistic Landmarker Result

### DIFF
--- a/mediapipe/tasks/ios/test/vision/holistic_landmarker/BUILD
+++ b/mediapipe/tasks/ios/test/vision/holistic_landmarker/BUILD
@@ -1,0 +1,63 @@
+load(
+    "//mediapipe/framework/tool:ios.bzl",
+    "MPP_TASK_MINIMUM_OS_VERSION",
+)
+load(
+    "@org_tensorflow//tensorflow/lite:special_rules.bzl",
+    "tflite_ios_lab_runner",
+)
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+
+package(default_visibility = ["//mediapipe/tasks:internal"])
+
+licenses(["notice"])
+
+# Default tags for filtering iOS targets. Targets are restricted to Apple platforms.
+TFL_DEFAULT_TAGS = [
+    "apple",
+]
+
+# Following sanitizer tests are not supported by iOS test targets.
+TFL_DISABLED_SANITIZER_TAGS = [
+    "noasan",
+    "nomsan",
+    "notsan",
+]
+
+objc_library(
+    name = "MPPHolisticLandmarkerObjcTestLibrary",
+    testonly = 1,
+    srcs = ["MPPHolisticLandmarkerTests.mm"],
+    copts = [
+        "-ObjC++",
+        "-std=c++17",
+        "-x objective-c++",
+    ],
+    data = [
+        "//mediapipe/tasks/testdata/vision:holistic_landmarker.task",
+        "//mediapipe/tasks/testdata/vision:test_images",
+        "//mediapipe/tasks/testdata/vision:test_protos",
+    ],
+    deps = [
+        "//mediapipe/tasks/ios/common:MPPCommon",
+        "//mediapipe/tasks/ios/common/utils:NSStringHelpers",
+        "//mediapipe/tasks/ios/test/vision/holistic_landmarker/utils:MPPHolisticLandmarkerResultProtobufHelpers",
+        "//mediapipe/tasks/ios/test/vision/utils:MPPImageTestUtils",
+        "//mediapipe/tasks/ios/vision/holistic_landmarker:MPPHolisticLandmarker",
+    ] + select({
+        "//third_party:opencv_ios_sim_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//third_party:opencv_ios_arm64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//third_party:opencv_ios_x86_64_source_build": ["@ios_opencv_source//:opencv_xcframework"],
+        "//conditions:default": ["@ios_opencv//:OpencvFramework"],
+    }),
+)
+
+ios_unit_test(
+    name = "MPPHolisticLandmarkerObjcTest",
+    minimum_os_version = MPP_TASK_MINIMUM_OS_VERSION,
+    runner = tflite_ios_lab_runner("IOS_LATEST"),
+    tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
+    deps = [
+        ":MPPHolisticLandmarkerObjcTestLibrary",
+    ],
+)

--- a/mediapipe/tasks/ios/test/vision/holistic_landmarker/MPPHolisticLandmarkerTests.mm
+++ b/mediapipe/tasks/ios/test/vision/holistic_landmarker/MPPHolisticLandmarkerTests.mm
@@ -1,0 +1,219 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "mediapipe/tasks/ios/common/sources/MPPCommon.h"
+#import "mediapipe/tasks/ios/common/utils/sources/NSString+Helpers.h"
+#import "mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.h"
+#import "mediapipe/tasks/ios/test/vision/utils/sources/MPPImage+TestUtils.h"
+#import "mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarker.h"
+
+static NSString *const kPbFileExtension = @"pbtxt";
+
+static MPPFileInfo *const kHolisticLandmarkerBundleAssetFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"holistic_landmarker" type:@"task"];
+
+static MPPFileInfo *const kHolisticImageFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"male_full_height_hands" type:@"jpg"];
+
+static MPPFileInfo *const kCatImageFileInfo = [[MPPFileInfo alloc] initWithName:@"cat" type:@"jpg"];
+
+static MPPFileInfo *const kExpectedHolisticLandmarksFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"male_full_height_hands_result_cpu" type:kPbFileExtension];
+
+static NSString *const kExpectedErrorDomain = @"com.google.mediapipe.tasks";
+static const float kLandmarksErrorTolerance = 0.03f;
+static const float kFaceBlendshapesErrorTolerance = 0.13f;
+
+#define AssertEqualErrors(error, expectedError)              \
+  XCTAssertNotNil(error);                                    \
+  XCTAssertEqualObjects(error.domain, expectedError.domain); \
+  XCTAssertEqual(error.code, expectedError.code);            \
+  XCTAssertEqualObjects(error.localizedDescription, expectedError.localizedDescription)
+
+#define AssertApproximatelyEqualLandmarks(landmark, expectedLandmark, landmarkTypeName,     \
+                                          landmarkIndex)                                    \
+  XCTAssertEqualWithAccuracy(landmark.x, expectedLandmark.x, kLandmarksErrorTolerance,      \
+                             @"landmark type = %@ landmark index = %d", landmarkTypeName,   \
+                             landmarkIndex);                                                \
+  XCTAssertEqualWithAccuracy(landmark.y, expectedLandmark.y, kLandmarksErrorTolerance,      \
+                             @"landmark type = %d landmark index j = %d", landmarkTypeName, \
+                             landmarkIndex);
+
+#define AssertEqualCategories(category, expectedCategory, categoryIndex, errorTolerance)       \
+  XCTAssertEqual(category.index, expectedCategory.index, @"index i = %d", categoryIndex);      \
+  XCTAssertEqualWithAccuracy(category.score, expectedCategory.score, errorTolerance,           \
+                             @"index i = %d", categoryIndex);                                  \
+  XCTAssertEqualObjects(category.categoryName, expectedCategory.categoryName, @"index i = %d", \
+                        categoryIndex);                                                        \
+  XCTAssertEqualObjects(category.displayName, expectedCategory.displayName, @"index i = %d",   \
+                        categoryIndex);
+
+@interface MPPHolisticLandmarkerTests : XCTestCase
+@end
+
+@implementation MPPHolisticLandmarkerTests
+
+#pragma mark General Tests
+
+- (void)testDetectWithModelPathSucceeds {
+  MPPHolisticLandmarker *holisticLandmarker =
+      [[MPPHolisticLandmarker alloc] initWithModelPath:kHolisticLandmarkerBundleAssetFileInfo.path
+                                                 error:nil];
+
+  XCTAssertNotNil(holisticLandmarker);
+
+  [self assertResultsOfDetectInImageWithFileInfo:kHolisticImageFileInfo
+                          usingHolisticLandmarker:holisticLandmarker
+      approximatelyEqualsHolisticLandmarkerResult:
+          [MPPHolisticLandmarkerTests
+              expectedHolisticLandmarkerResultWithFileInfo:kExpectedHolisticLandmarksFileInfo]];
+}
+
+- (void)testDetectWithOptionsSucceeds {
+  MPPHolisticLandmarkerOptions *options =
+      [self holisticLandmarkerOptionsWithModelFileInfo:kHolisticLandmarkerBundleAssetFileInfo];
+  MPPHolisticLandmarker *holisticLandmarker =
+      [self createHolisticLandmarkerWithOptionsSucceeds:options];
+
+  [self assertResultsOfDetectInImageWithFileInfo:kHolisticImageFileInfo
+                          usingHolisticLandmarker:holisticLandmarker
+      approximatelyEqualsHolisticLandmarkerResult:
+          [MPPHolisticLandmarkerTests
+              expectedHolisticLandmarkerResultWithFileInfo:kExpectedHolisticLandmarksFileInfo]];
+}
+
+#pragma mark Pose Landmarker Initializers
+
+- (MPPHolisticLandmarkerOptions *)holisticLandmarkerOptionsWithModelFileInfo:
+    (MPPFileInfo *)modelFileInfo {
+  MPPHolisticLandmarkerOptions *holisticLandmarkerOptions =
+      [[MPPHolisticLandmarkerOptions alloc] init];
+  holisticLandmarkerOptions.baseOptions.modelAssetPath = modelFileInfo.path;
+
+  return holisticLandmarkerOptions;
+}
+
+- (MPPHolisticLandmarker *)createHolisticLandmarkerWithOptionsSucceeds:
+    (MPPHolisticLandmarkerOptions *)holisticLandmarkerOptions {
+  NSError *error;
+  MPPHolisticLandmarker *holisticLandmarker =
+      [[MPPHolisticLandmarker alloc] initWithOptions:holisticLandmarkerOptions error:&error];
+  XCTAssertNotNil(holisticLandmarker);
+  XCTAssertNil(error);
+
+  return holisticLandmarker;
+}
+
+- (void)assertCreateHolisticLandmarkerWithOptions:
+            (MPPHolisticLandmarkerOptions *)holisticLandmarkerOptions
+                           failsWithExpectedError:(NSError *)expectedError {
+  NSError *error = nil;
+  MPPHolisticLandmarker *holisticLandmarker =
+      [[MPPHolisticLandmarker alloc] initWithOptions:holisticLandmarkerOptions error:&error];
+
+  XCTAssertNil(holisticLandmarker);
+  AssertEqualErrors(error, expectedError);
+}
+
+#pragma mark Results
+
++ (MPPHolisticLandmarkerResult *)expectedHolisticLandmarkerResultWithFileInfo:
+    (MPPFileInfo *)fileInfo {
+  MPPHolisticLandmarkerResult *result =
+      [MPPHolisticLandmarkerResult holisticLandmarkerResultFromProtobufFileWithName:fileInfo.path];
+
+  return result;
+}
+
+- (void)assertResultsOfDetectInImageWithFileInfo:(MPPFileInfo *)fileInfo
+                         usingHolisticLandmarker:(MPPHolisticLandmarker *)holisticLandmarker
+     approximatelyEqualsHolisticLandmarkerResult:
+         (MPPHolisticLandmarkerResult *)expectedHolisticLandmarkerResult {
+  MPPHolisticLandmarkerResult *holisticLandmarkerResult =
+      [self detectImageWithFileInfo:fileInfo usingHolisticLandmarker:holisticLandmarker];
+  [self assertHolisticLandmarkerResult:holisticLandmarkerResult
+      isApproximatelyEqualToExpectedResult:expectedHolisticLandmarkerResult];
+}
+
+- (MPPHolisticLandmarkerResult *)detectImageWithFileInfo:(MPPFileInfo *)imageFileInfo
+                                 usingHolisticLandmarker:
+                                     (MPPHolisticLandmarker *)holisticLandmarker {
+  MPPImage *image = [MPPImage imageWithFileInfo:imageFileInfo];
+
+  NSError *error;
+
+  MPPHolisticLandmarkerResult *holisticLandmarkerResult = [holisticLandmarker detectImage:image
+                                                                                    error:&error];
+  XCTAssertNotNil(holisticLandmarkerResult);
+
+  return holisticLandmarkerResult;
+}
+
+- (void)assertHolisticLandmarkerResult:(MPPHolisticLandmarkerResult *)holisticLandmarkerResult
+    isApproximatelyEqualToExpectedResult:
+        (MPPHolisticLandmarkerResult *)expectedHolisticLandmarkerResult {
+  [self assertNormalizedLandmarks:holisticLandmarkerResult.faceLandmarks
+                                    withLandmarkTypeName:@"face_landmarks"
+      areApproximatelyEqualToExpectedNormalizedLandmarks:expectedHolisticLandmarkerResult
+                                                             .faceLandmarks];
+
+  [self assertNormalizedLandmarks:holisticLandmarkerResult.poseLandmarks
+                                    withLandmarkTypeName:@"pose_landmarks"
+      areApproximatelyEqualToExpectedNormalizedLandmarks:expectedHolisticLandmarkerResult
+                                                             .poseLandmarks];
+
+  [self assertNormalizedLandmarks:holisticLandmarkerResult.leftHandLandmarks
+                                    withLandmarkTypeName:@"left_hand_landmarks"
+      areApproximatelyEqualToExpectedNormalizedLandmarks:expectedHolisticLandmarkerResult
+                                                             .leftHandLandmarks];
+
+  [self assertNormalizedLandmarks:holisticLandmarkerResult.rightHandLandmarks
+                                    withLandmarkTypeName:@"right_hand_landmarks"
+      areApproximatelyEqualToExpectedNormalizedLandmarks:expectedHolisticLandmarkerResult
+                                                             .rightHandLandmarks];
+
+  [self assertfaceBlendshapes:holisticLandmarkerResult.faceBlendshapes
+      areApproximatelyEqualToExpectedFaceBlendshapes:expectedHolisticLandmarkerResult
+                                                         .faceBlendshapes];
+}
+
+- (void)assertNormalizedLandmarks:(NSArray<MPPNormalizedLandmark *> *)normalizedLandmarks
+                                  withLandmarkTypeName:(NSString *)landmarkTypeName
+    areApproximatelyEqualToExpectedNormalizedLandmarks:
+        (NSArray<MPPNormalizedLandmark *> *)expectedNormalizedLandmarks {
+  XCTAssertEqual(normalizedLandmarks.count, expectedNormalizedLandmarks.count);
+
+  for (int i = 0; i < expectedNormalizedLandmarks.count; i++) {
+    MPPNormalizedLandmark *landmark = normalizedLandmarks[i];
+    XCTAssertNotNil(landmark);
+    AssertApproximatelyEqualLandmarks(landmark, expectedNormalizedLandmarks[i], landmarkTypeName,
+                                      i);
+  }
+}
+
+- (void)assertfaceBlendshapes:(MPPClassifications *)faceBlendshapes
+    areApproximatelyEqualToExpectedFaceBlendshapes:(MPPClassifications *)expectedFaceBlendshapes {
+  XCTAssertEqual(faceBlendshapes.categories.count, expectedFaceBlendshapes.categories.count);
+
+  for (int i = 0; i < expectedFaceBlendshapes.categories.count; i++) {
+    MPPCategory *faceBlendshape = faceBlendshapes.categories[i];
+    XCTAssertNotNil(faceBlendshape);
+    AssertEqualCategories(faceBlendshape, expectedFaceBlendshapes.categories[i], i,
+                          kFaceBlendshapesErrorTolerance);
+  }
+}
+
+@end

--- a/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/BUILD
+++ b/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2023 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//mediapipe/tasks:internal"])
+
+licenses(["notice"])
+
+objc_library(
+    name = "MPPHolisticLandmarkerResultProtobufHelpers",
+    srcs = ["sources/MPPHolisticLandmarkerResult+ProtobufHelpers.mm"],
+    hdrs = ["sources/MPPHolisticLandmarkerResult+ProtobufHelpers.h"],
+    copts = [
+        "-ObjC++",
+        "-std=c++17",
+        "-x objective-c++",
+    ],
+    deps = [
+        "//mediapipe/tasks/cc/vision/holistic_landmarker/proto:holistic_result_cc_proto",
+        "//mediapipe/tasks/ios/common/utils:NSStringHelpers",
+        "//mediapipe/tasks/ios/test/vision/utils:parse_proto_utils",
+        "//mediapipe/tasks/ios/vision/holistic_landmarker:MPPHolisticLandmarkerResult",
+        "//mediapipe/tasks/ios/vision/holistic_landmarker/utils:MPPHolisticLandmarkerResultHelpers",
+    ],
+)

--- a/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.h
+++ b/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.h
@@ -1,0 +1,26 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.h"
+
+NS_ASSUME_NONNULL_BEGIN
+@interface MPPHolisticLandmarkerResult (ProtobufHelpers)
+
++ (MPPHolisticLandmarkerResult *)holisticLandmarkerResultFromProtobufFileWithName:
+    (NSString *)fileName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.mm
+++ b/mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.mm
@@ -1,0 +1,55 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "mediapipe/tasks/ios/test/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+ProtobufHelpers.h"
+
+#import "mediapipe/tasks/ios/common/utils/sources/NSString+Helpers.h"
+#import "mediapipe/tasks/ios/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+Helpers.h"
+
+#include "mediapipe/tasks/cc/vision/holistic_landmarker/proto/holistic_result.pb.h"
+#include "mediapipe/tasks/ios/test/vision/utils/sources/parse_proto_utils.h"
+
+namespace {
+using ::mediapipe::ClassificationList;
+using ::mediapipe::LandmarkList;
+using ::mediapipe::tasks::ios::test::vision::utils::get_proto_from_pbtxt;
+using ::mediapipe::tasks::vision::holistic_landmarker::proto::HolisticResult;
+};  // anonymous namespace
+
+@implementation MPPHolisticLandmarkerResult (ProtobufHelpers)
+
++ (MPPHolisticLandmarkerResult *)holisticLandmarkerResultFromProtobufFileWithName:
+    (NSString *)fileName {
+  HolisticResult holisticResultProto;
+
+  if (!get_proto_from_pbtxt(fileName.cppString, holisticResultProto).ok()) {
+    return nil;
+  }
+
+  const ClassificationList faceBlendshapesProto = holisticResultProto.face_blendshapes();
+
+  return [MPPHolisticLandmarkerResult
+      holisticLandmarkerResultWithFaceLandmarksProto:holisticResultProto.face_landmarks()
+                                faceBlendshapesProto:&faceBlendshapesProto
+                                  poseLandmarksProto:holisticResultProto.pose_landmarks()
+                             poseWorldLandmarksProto:LandmarkList()
+                          poseSegmentationMaskProtos:nil
+                              leftHandLandmarksProto:holisticResultProto.left_hand_landmarks()
+                         leftHandWorldLandmarksProto:LandmarkList()
+                             rightHandLandmarksProto:holisticResultProto.right_hand_landmarks()
+                        rightHandWorldLandmarksProto:LandmarkList()
+                             timestampInMilliseconds:0];
+}
+
+@end

--- a/mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.h
+++ b/mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.h
@@ -25,31 +25,31 @@ NS_SWIFT_NAME(HolisticLandmarkerResult)
 @interface MPPHolisticLandmarkerResult : MPPTaskResult
 
 /** Detected face landmarks in normalized image coordinates. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPNormalizedLandmark *> *> *faceLandmarks;
+@property(nonatomic, readonly) NSArray<MPPNormalizedLandmark *> *faceLandmarks;
 
 /** Face blendshapes results. Defaults to `nil` if not enabled. */
-@property(nonatomic, readonly, nullable) NSArray<MPPClassifications *> *faceBlendshapes;
+@property(nonatomic, readonly, nullable) MPPClassifications *faceBlendshapes;
 
 /** Detected pose landmarks in normalized image coordinates. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPNormalizedLandmark *> *> *poseLandmarks;
+@property(nonatomic, readonly) NSArray<MPPNormalizedLandmark *> *poseLandmarks;
 
 /** Pose landmarks in world coordinates of detected poses. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPLandmark *> *> *poseWorldLandmarks;
+@property(nonatomic, readonly) NSArray<MPPLandmark *> *poseWorldLandmarks;
 
 /** Optional segmentation mask for the detected pose. Defaults to `nil` if not enabled.*/
 @property(nonatomic, readonly, nullable) NSArray<MPPMask *> *poseSegmentationMasks;
 
 /** Left hand landmarks in normalized image coordinates of detected left hands. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPNormalizedLandmark *> *> *leftHandLandmarks;
+@property(nonatomic, readonly) NSArray<MPPNormalizedLandmark *> *leftHandLandmarks;
 
 /** Left hand landmarks in world coordinates of detected left hands. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPLandmark *> *> *leftHandWorldLandmarks;
+@property(nonatomic, readonly) NSArray<MPPLandmark *> *leftHandWorldLandmarks;
 
 /** Right hand landmarks in normalized image coordinates of detected right hands. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPNormalizedLandmark *> *> *rightHandLandmarks;
+@property(nonatomic, readonly) NSArray<MPPNormalizedLandmark *> *rightHandLandmarks;
 
 /** Right hand landmarks in world coordinates of detected right hands. */
-@property(nonatomic, readonly) NSArray<NSArray<MPPLandmark *> *> *rightHandWorldLandmarks;
+@property(nonatomic, readonly) NSArray<MPPLandmark *> *rightHandWorldLandmarks;
 
 /**
  * Initializes a new `HolisticLandmarkerResult` with the given array of face landmarks, face
@@ -73,17 +73,16 @@ NS_SWIFT_NAME(HolisticLandmarkerResult)
  * hand landmarks, left hand world landmarks, right hand landmarks, right hand world landmarks and
  * timestamp (in milliseconds).
  */
-- (instancetype)
-      initWithFaceLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)faceLandmarks
-            faceBlendshapes:(nullable NSArray<MPPClassifications *> *)faceBlendshapes
-              poseLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)poseLandmarks
-         poseWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)poseWorldLandmarks
-      poseSegmentationMasks:(NSArray<MPPMask *> *)poseSegmentationMasks
-          leftHandLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)leftHandLandmarks
-     leftHandWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)leftHandWorldLandmarks
-         rightHandLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)rightHandLandmarks
-    rightHandWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)rightHandWorldLandmarks
-    timestampInMilliseconds:(NSInteger)timestampInMilliseconds NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithFaceLandmarks:(NSArray<MPPNormalizedLandmark *> *)faceLandmarks
+                      faceBlendshapes:(nullable MPPClassifications *)faceBlendshapes
+                        poseLandmarks:(NSArray<MPPNormalizedLandmark *> *)poseLandmarks
+                   poseWorldLandmarks:(NSArray<MPPLandmark *> *)poseWorldLandmarks
+                poseSegmentationMasks:(NSArray<MPPMask *> *)poseSegmentationMasks
+                    leftHandLandmarks:(NSArray<MPPNormalizedLandmark *> *)leftHandLandmarks
+               leftHandWorldLandmarks:(NSArray<MPPLandmark *> *)leftHandWorldLandmarks
+                   rightHandLandmarks:(NSArray<MPPNormalizedLandmark *> *)rightHandLandmarks
+              rightHandWorldLandmarks:(NSArray<MPPLandmark *> *)rightHandWorldLandmarks
+              timestampInMilliseconds:(NSInteger)timestampInMilliseconds NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithTimestampInMilliseconds:(NSInteger)timestampInMilliseconds NS_UNAVAILABLE;
 

--- a/mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.m
+++ b/mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.m
@@ -19,15 +19,15 @@
 @implementation MPPHolisticLandmarkerResult
 
 - (instancetype)
-      initWithFaceLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)faceLandmarks
-            faceBlendshapes:(nullable NSArray<MPPClassifications *> *)faceBlendshapes
-              poseLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)poseLandmarks
-         poseWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)poseWorldLandmarks
+      initWithFaceLandmarks:(NSArray<MPPNormalizedLandmark *> *)faceLandmarks
+            faceBlendshapes:(nullable MPPClassifications *)faceBlendshapes
+              poseLandmarks:(NSArray<MPPNormalizedLandmark *> *)poseLandmarks
+         poseWorldLandmarks:(NSArray<MPPLandmark *> *)poseWorldLandmarks
       poseSegmentationMasks:(NSArray<MPPMask *> *)poseSegmentationMasks
-          leftHandLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)leftHandLandmarks
-     leftHandWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)leftHandWorldLandmarks
-         rightHandLandmarks:(NSArray<NSArray<MPPNormalizedLandmark *> *> *)rightHandLandmarks
-    rightHandWorldLandmarks:(NSArray<NSArray<MPPLandmark *> *> *)rightHandWorldLandmarks
+          leftHandLandmarks:(NSArray<MPPNormalizedLandmark *> *)leftHandLandmarks
+     leftHandWorldLandmarks:(NSArray<MPPLandmark *> *)leftHandWorldLandmarks
+         rightHandLandmarks:(NSArray<MPPNormalizedLandmark *> *)rightHandLandmarks
+    rightHandWorldLandmarks:(NSArray<MPPLandmark *> *)rightHandWorldLandmarks
     timestampInMilliseconds:(NSInteger)timestampInMilliseconds {
   self = [super initWithTimestampInMilliseconds:timestampInMilliseconds];
   if (self) {

--- a/mediapipe/tasks/ios/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+Helpers.h
+++ b/mediapipe/tasks/ios/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+Helpers.h
@@ -16,7 +16,11 @@
 #error "This file requires Objective-C++."
 #endif  // __cplusplus
 
+#include "mediapipe/framework/formats/classification.pb.h"
+#include "mediapipe/framework/formats/image.h"
+#include "mediapipe/framework/formats/landmark.pb.h"
 #include "mediapipe/framework/packet.h"
+
 #import "mediapipe/tasks/ios/vision/holistic_landmarker/sources/MPPHolisticLandmarkerResult.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -26,7 +30,7 @@ static const int kMicrosecondsPerMillisecond = 1000;
 @interface MPPHolisticLandmarkerResult (Helpers)
 
 /**
- * Creates an `MPPHolisticLandmarkerResult` from face landmarks, face blend shapes, pose landmarks,
+ * Creates a `MPPHolisticLandmarkerResult` from face landmarks, face blend shapes, pose landmarks,
  * pose world landmarks, pose segmentation masks, left hand landmarks, left hand world landmarks,
  * right hand landmarks and right hand world landmarks packets.
  *
@@ -68,5 +72,46 @@ static const int kMicrosecondsPerMillisecond = 1000;
                       rightHandWorldLandmarksPacket:
                           (const mediapipe::Packet &)rightHandWorldLandmarksPacket;
 
+/**
+ * Creates a `MPPHolisticLandmarkerResult` from face landmarks, face blend shapes, pose landmarks,
+ * pose world landmarks, pose segmentation masks, left hand landmarks, left hand world landmarks,
+ * right hand landmarks, right hand world landmarks and timestamp in milliseconds.
+ *
+ * @param faceLandmarksProto A proto of type `mediapipe::NormalizedlandmarkList`.
+ * @param faceBlendshapesProto A proto of type `mediapipe::ClassificationList`.
+ * @param poseLandmarksProto A proto of type `mediapipe::NormalizedlandmarkList`.
+ * @param poseWorldLandmarksProto A proto of type `mediapipe::LandmarkList`.
+ * @param poseSegmentationMaskProtos A list of protos of type `std::vector<mediapipe::Image>`.
+ * @param leftHandLandmarksProto A proto of type `mediapipe::NormalizedlandmarkList`.
+ * @param leftHandWorldLandmarksProto A proto of type `mediapipe::LandmarkList`.
+ * @param rightHandLandmarksProto A proto of type `mediapipe::NormalizedlandmarkList`.
+ * @param rightHandWorldLandmarksProto A proto of type `mediapipe::LandmarkList`.
+ * @param timestampInMilliseconds The timestamp of the result.
+ *
+ * @return  A `MPPHolisticLandmarkerResult` object created from the given protos and timestamp in
+ * milliseconds.
+ */
++ (MPPHolisticLandmarkerResult *)
+    holisticLandmarkerResultWithFaceLandmarksProto:
+        (const ::mediapipe::NormalizedLandmarkList &)faceLandmarksProto
+                              faceBlendshapesProto:
+                                  (const ::mediapipe::ClassificationList *)faceBlendshapesProto
+                                poseLandmarksProto:
+                                    (const ::mediapipe::NormalizedLandmarkList &)poseLandmarksProto
+                           poseWorldLandmarksProto:
+                               (const ::mediapipe::LandmarkList &)poseWorldLandmarksProto
+                        poseSegmentationMaskProtos:
+                            (const std::vector<::mediapipe::Image> *)poseSegmentationMaskProtos
+                            leftHandLandmarksProto:
+                                (const ::mediapipe::NormalizedLandmarkList &)leftHandLandmarksProto
+                       leftHandWorldLandmarksProto:
+                           (const ::mediapipe::LandmarkList &)leftHandWorldLandmarksProto
+                           rightHandLandmarksProto:
+                               (const ::mediapipe::NormalizedLandmarkList &)rightHandLandmarksProto
+                      rightHandWorldLandmarksProto:
+                          (const ::mediapipe::LandmarkList &)rightHandWorldLandmarksProto
+                           timestampInMilliseconds:(NSInteger)timestampInMilliseconds;
+
 @end
+
 NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+Helpers.mm
+++ b/mediapipe/tasks/ios/vision/holistic_landmarker/utils/sources/MPPHolisticLandmarkerResult+Helpers.mm
@@ -28,6 +28,15 @@ using NormalizedLandmarkListProto = ::mediapipe::NormalizedLandmarkList;
 using ClassificationListProto = ::mediapipe::ClassificationList;
 };  // namespace
 
+#define NormalizedLandmarkListFromPacket(packet)            \
+  packet.ValidateAsType<NormalizedLandmarkListProto>().ok() \
+      ? packet.Get<NormalizedLandmarkListProto>()           \
+      : NormalizedLandmarkListProto()
+
+#define LandmarkListFromPacket(packet)                                              \
+  packet.ValidateAsType<LandmarkListProto>().ok() ? packet.Get<LandmarkListProto>() \
+                                                  : LandmarkListProto()
+
 @implementation MPPHolisticLandmarkerResult (Helpers)
 
 + (MPPHolisticLandmarkerResult *)
@@ -46,47 +55,90 @@ using ClassificationListProto = ::mediapipe::ClassificationList;
                                (const mediapipe::Packet &)rightHandLandmarksPacket
                       rightHandWorldLandmarksPacket:
                           (const mediapipe::Packet &)rightHandWorldLandmarksPacket {
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *faceLandmarks =
-      [MPPHolisticLandmarkerResult normalizedLandmarksArrayFromPacket:faceLandmarksPacket];
+  NSInteger timestampInMilliseconds =
+      (NSInteger)(faceLandmarksPacket.Timestamp().Value() / kMicrosecondsPerMillisecond);
 
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *poseLandmarks =
-      [MPPHolisticLandmarkerResult normalizedLandmarksArrayFromPacket:poseLandmarksPacket];
-  NSMutableArray<NSArray<MPPLandmark *> *> *poseWorldLandmarks =
-      [MPPHolisticLandmarkerResult landmarksArrayFromPacket:poseWorldLandmarksPacket];
+  const ClassificationListProto *faceBlendshapesProto =
+      faceBlendShapesPacket.ValidateAsType<ClassificationListProto>().ok()
+          ? &(faceBlendShapesPacket.Get<ClassificationListProto>())
+          : nullptr;
+  const std::vector<Image> *poseSegmentationMasksProto =
+      poseSegmentationMasksPacket->ValidateAsType<std::vector<Image>>().ok()
+          ? &(poseSegmentationMasksPacket->Get<std::vector<Image>>())
+          : nullptr;
 
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *leftHandLandmarks =
-      [MPPHolisticLandmarkerResult normalizedLandmarksArrayFromPacket:leftHandLandmarksPacket];
-  NSMutableArray<NSArray<MPPLandmark *> *> *leftHandWorldLandmarks =
-      [MPPHolisticLandmarkerResult landmarksArrayFromPacket:leftHandWorldLandmarksPacket];
+  return [MPPHolisticLandmarkerResult
+      holisticLandmarkerResultWithFaceLandmarksProto:NormalizedLandmarkListFromPacket(
+                                                         faceLandmarksPacket)
+                                faceBlendshapesProto:faceBlendshapesProto
+                                  poseLandmarksProto:NormalizedLandmarkListFromPacket(
+                                                         poseLandmarksPacket)
+                             poseWorldLandmarksProto:LandmarkListFromPacket(poseLandmarksPacket)
+                          poseSegmentationMaskProtos:poseSegmentationMasksProto
+                              leftHandLandmarksProto:NormalizedLandmarkListFromPacket(
+                                                         leftHandLandmarksPacket)
+                         leftHandWorldLandmarksProto:LandmarkListFromPacket(
+                                                         leftHandWorldLandmarksPacket)
+                             rightHandLandmarksProto:NormalizedLandmarkListFromPacket(
+                                                         rightHandLandmarksPacket)
+                        rightHandWorldLandmarksProto:LandmarkListFromPacket(
+                                                         rightHandWorldLandmarksPacket)
+                             timestampInMilliseconds:timestampInMilliseconds];
+}
 
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *rightHandLandmarks =
-      [MPPHolisticLandmarkerResult normalizedLandmarksArrayFromPacket:rightHandLandmarksPacket];
-  NSMutableArray<NSArray<MPPLandmark *> *> *rightHandWorldLandmarks =
-      [MPPHolisticLandmarkerResult landmarksArrayFromPacket:rightHandWorldLandmarksPacket];
++ (MPPHolisticLandmarkerResult *)
+    holisticLandmarkerResultWithFaceLandmarksProto:
+        (const ::mediapipe::NormalizedLandmarkList &)faceLandmarksProto
+                              faceBlendshapesProto:
+                                  (const ::mediapipe::ClassificationList *)faceBlendshapesProto
+                                poseLandmarksProto:
+                                    (const ::mediapipe::NormalizedLandmarkList &)poseLandmarksProto
+                           poseWorldLandmarksProto:
+                               (const ::mediapipe::LandmarkList &)poseWorldLandmarksProto
+                        poseSegmentationMaskProtos:
+                            (const std::vector<::mediapipe::Image> *)poseSegmentationMaskProtos
+                            leftHandLandmarksProto:
+                                (const ::mediapipe::NormalizedLandmarkList &)leftHandLandmarksProto
+                       leftHandWorldLandmarksProto:
+                           (const ::mediapipe::LandmarkList &)leftHandWorldLandmarksProto
+                           rightHandLandmarksProto:
+                               (const ::mediapipe::NormalizedLandmarkList &)rightHandLandmarksProto
+                      rightHandWorldLandmarksProto:
+                          (const ::mediapipe::LandmarkList &)rightHandWorldLandmarksProto
+                           timestampInMilliseconds:(NSInteger)timestampInMilliseconds {
+  NSArray<MPPNormalizedLandmark *> *faceLandmarks = [MPPHolisticLandmarkerResult
+      normalizedLandmarksArrayFromNormalizedLandmarkListProto:faceLandmarksProto];
+
+  NSArray<MPPNormalizedLandmark *> *poseLandmarks = [MPPHolisticLandmarkerResult
+      normalizedLandmarksArrayFromNormalizedLandmarkListProto:poseLandmarksProto];
+  NSArray<MPPLandmark *> *poseWorldLandmarks =
+      [MPPHolisticLandmarkerResult landmarksArrayFromLandmarkListProto:poseWorldLandmarksProto];
+
+  NSArray<MPPNormalizedLandmark *> *leftHandLandmarks = [MPPHolisticLandmarkerResult
+      normalizedLandmarksArrayFromNormalizedLandmarkListProto:leftHandLandmarksProto];
+  NSArray<MPPLandmark *> *leftHandWorldLandmarks =
+      [MPPHolisticLandmarkerResult landmarksArrayFromLandmarkListProto:leftHandWorldLandmarksProto];
+
+  NSArray<MPPNormalizedLandmark *> *rightHandLandmarks = [MPPHolisticLandmarkerResult
+      normalizedLandmarksArrayFromNormalizedLandmarkListProto:rightHandLandmarksProto];
+  NSArray<MPPLandmark *> *rightHandWorldLandmarks = [MPPHolisticLandmarkerResult
+      landmarksArrayFromLandmarkListProto:rightHandWorldLandmarksProto];
 
   // Since the presence of faceBlendshapes and poseConfidenceMasks are optional, if they are not
   // present pass nil arrays to the result.
-  NSMutableArray<MPPClassifications *> *faceBlendshapes;
-  if (faceBlendShapesPacket.ValidateAsType<std::vector<ClassificationListProto>>().ok()) {
-    const std::vector<ClassificationListProto> &classificationListProtos =
-        faceBlendShapesPacket.Get<std::vector<ClassificationListProto>>();
-    faceBlendshapes =
-        [NSMutableArray arrayWithCapacity:(NSUInteger)classificationListProtos.size()];
-    for (const auto &classificationListProto : classificationListProtos) {
-      [faceBlendshapes
-          addObject:[MPPClassifications
-                        classificationsWithClassificationListProto:classificationListProto
+  MPPClassifications *faceBlendshapes;
+  if (faceBlendshapesProto) {
+    [MPPClassifications classificationsWithClassificationListProto:*faceBlendshapesProto
                                                          headIndex:0
-                                                          headName:@""]];
-    }
+                                                          headName:@""];
   }
 
   NSMutableArray<MPPMask *> *poseConfidenceMasks;
-  if (poseSegmentationMasksPacket->ValidateAsType<std::vector<Image>>().ok()) {
-    std::vector<Image> cppConfidenceMasks = poseSegmentationMasksPacket->Get<std::vector<Image>>();
-    poseConfidenceMasks = [NSMutableArray arrayWithCapacity:(NSUInteger)cppConfidenceMasks.size()];
+  if (poseSegmentationMaskProtos) {
+    poseConfidenceMasks =
+        [NSMutableArray arrayWithCapacity:(NSUInteger)poseSegmentationMaskProtos->size()];
 
-    for (const auto &confidenceMask : cppConfidenceMasks) {
+    for (const auto &confidenceMask : *poseSegmentationMaskProtos) {
       [poseConfidenceMasks
           addObject:[[MPPMask alloc]
                         initWithFloat32Data:(float *)confidenceMask.GetImageFrameSharedPtr()
@@ -98,84 +150,41 @@ using ClassificationListProto = ::mediapipe::ClassificationList;
     }
   }
 
-  return [[MPPHolisticLandmarkerResult alloc]
-        initWithFaceLandmarks:faceLandmarks
-              faceBlendshapes:faceBlendshapes
-                poseLandmarks:poseLandmarks
-           poseWorldLandmarks:poseWorldLandmarks
-        poseSegmentationMasks:poseConfidenceMasks
-            leftHandLandmarks:leftHandLandmarks
-       leftHandWorldLandmarks:leftHandWorldLandmarks
-           rightHandLandmarks:rightHandLandmarks
-      rightHandWorldLandmarks:rightHandWorldLandmarks
-      timestampInMilliseconds:(NSInteger)(faceLandmarksPacket.Timestamp().Value() /
-                                          kMicrosecondsPerMillisecond)];
+  return [[MPPHolisticLandmarkerResult alloc] initWithFaceLandmarks:faceLandmarks
+                                                    faceBlendshapes:faceBlendshapes
+                                                      poseLandmarks:poseLandmarks
+                                                 poseWorldLandmarks:poseWorldLandmarks
+                                              poseSegmentationMasks:poseConfidenceMasks
+                                                  leftHandLandmarks:leftHandLandmarks
+                                             leftHandWorldLandmarks:leftHandWorldLandmarks
+                                                 rightHandLandmarks:rightHandLandmarks
+                                            rightHandWorldLandmarks:rightHandWorldLandmarks
+                                            timestampInMilliseconds:timestampInMilliseconds];
 }
 
-+ (NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *)normalizedLandmarksArrayFromPacket:
-    (const mediapipe::Packet &)normalizedLandmarksPacket {
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *normalizedLandmarks =
-      [MPPHolisticLandmarkerResult
-          nullableNormalizedLandmarksArrayFromPacket:normalizedLandmarksPacket];
++ (NSArray<MPPNormalizedLandmark *> *)normalizedLandmarksArrayFromNormalizedLandmarkListProto:
+    (const NormalizedLandmarkListProto &)normalizedLandmarkListProto {
+  NSMutableArray<MPPNormalizedLandmark *> *normalizedLandmarks =
+      [NSMutableArray arrayWithCapacity:(NSUInteger)normalizedLandmarkListProto.landmark().size()];
+  for (const auto &normalizedLandmark : normalizedLandmarkListProto.landmark()) {
+    [normalizedLandmarks
+        addObject:[MPPNormalizedLandmark normalizedLandmarkWithProto:normalizedLandmark]];
+  }
 
-  return normalizedLandmarks ? normalizedLandmarks : [NSMutableArray arrayWithCapacity:0];
+  return normalizedLandmarks;
 }
 
-+ (NSMutableArray<NSArray<MPPLandmark *> *> *)landmarksArrayFromPacket:
-    (const mediapipe::Packet &)landmarksPacket {
-  NSMutableArray<NSArray<MPPLandmark *> *> *landmarks =
-      [MPPHolisticLandmarkerResult nullableLandmarksArrayFromPacket:landmarksPacket];
++ (NSArray<MPPLandmark *> *)landmarksArrayFromLandmarkListProto:
+    (const LandmarkListProto &)landmarkListProto {
+  NSMutableArray<MPPLandmark *> *landmarks =
+      [NSMutableArray arrayWithCapacity:(NSUInteger)landmarkListProto.landmark().size()];
 
-  return landmarks ? landmarks : [NSMutableArray arrayWithCapacity:0];
-}
-
-+ (NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *)nullableNormalizedLandmarksArrayFromPacket:
-    (const mediapipe::Packet &)normalizedLandmarksPacket {
-  if (!normalizedLandmarksPacket.ValidateAsType<std::vector<NormalizedLandmarkListProto>>().ok()) {
-    return nil;
+  for (const auto &landmarkProto : landmarkListProto.landmark()) {
+    MPPLandmark *landmark = [MPPLandmark landmarkWithProto:landmarkProto];
+    [landmarks addObject:landmark];
   }
 
-  const std::vector<NormalizedLandmarkListProto> &normalizedLandmarkListProtos =
-      normalizedLandmarksPacket.Get<std::vector<NormalizedLandmarkListProto>>();
-
-  NSMutableArray<NSArray<MPPNormalizedLandmark *> *> *multipleNormalizedLandmarks =
-      [NSMutableArray arrayWithCapacity:(NSUInteger)normalizedLandmarkListProtos.size()];
-  for (const auto &normalizedLandmarkListProto : normalizedLandmarkListProtos) {
-    NSMutableArray<MPPNormalizedLandmark *> *normalizedLandmarks =
-        [NSMutableArray arrayWithCapacity:(NSUInteger)normalizedLandmarkListProto.landmark_size()];
-    for (const auto &normalizedLandmark : normalizedLandmarkListProto.landmark()) {
-      [normalizedLandmarks
-          addObject:[MPPNormalizedLandmark normalizedLandmarkWithProto:normalizedLandmark]];
-    }
-    [multipleNormalizedLandmarks addObject:normalizedLandmarks];
-  }
-
-  return multipleNormalizedLandmarks;
-}
-
-+ (NSMutableArray<NSArray<MPPLandmark *> *> *)nullableLandmarksArrayFromPacket:
-    (const mediapipe::Packet &)landmarksPacket {
-  if (!landmarksPacket.ValidateAsType<std::vector<LandmarkListProto>>().ok()) {
-    return nil;
-  }
-
-  const std::vector<LandmarkListProto> &landmarkListProtos =
-      landmarksPacket.Get<std::vector<LandmarkListProto>>();
-
-  NSMutableArray<NSArray<MPPLandmark *> *> *multipleLandmarks =
-      [NSMutableArray arrayWithCapacity:(NSUInteger)landmarkListProtos.size()];
-
-  for (const auto &landmarkListProto : landmarkListProtos) {
-    NSMutableArray<MPPLandmark *> *landmarks =
-        [NSMutableArray arrayWithCapacity:(NSUInteger)landmarkListProto.landmark().size()];
-    for (const auto &landmarkProto : landmarkListProto.landmark()) {
-      MPPLandmark *landmark = [MPPLandmark landmarkWithProto:landmarkProto];
-      [landmarks addObject:landmark];
-    }
-    [multipleLandmarks addObject:landmarks];
-  }
-
-  return multipleLandmarks;
+  return landmarks;
 }
 
 @end


### PR DESCRIPTION
1. Fixed types in MPPHolisticLandmarkerResult
2. Added utility to create holistic landmarker result from photos
3. Added helpers for initialising holistic landmarker result from protobuf file.
4. Added basic Objective C holistic landmarker tests.