### PR TITLE
Fix using mediapipe from worker loaded as module

### DIFF
--- a/mediapipe/framework/tool/mediapipe_files.bzl
+++ b/mediapipe/framework/tool/mediapipe_files.bzl
@@ -14,10 +14,22 @@ def mediapipe_files(srcs):
 
     for src in srcs:
         archive_name = "com_google_mediapipe_%s" % src.replace("/", "_").replace(".", "_")
-        native.genrule(
-            name = "%s_ln" % archive_name,
-            srcs = ["@%s//file" % archive_name],
-            outs = [src],
-            output_to_bindir = 1,
-            cmd = "ln $< $@",
-        )
+        if src.endswith("_internal.js"):
+          native.genrule(
+              name = "%s_ln" % archive_name,
+              srcs = ["@%s//file" % archive_name],
+              outs = [src],
+              output_to_bindir = 1,
+              cmd = """
+              cp $< $@
+              echo 'else {\n  (globalThis || self || window).ModuleFactory = ModuleFactory;\n  (globalThis || self || window).custom_dbg = function(text) {\n    console.warn.apply(console, arguments);\n  }\n}\n' >> $@
+              """
+          )
+        else: 
+          native.genrule(
+              name = "%s_ln" % archive_name,
+              srcs = ["@%s//file" % archive_name],
+              outs = [src],
+              output_to_bindir = 1,
+              cmd = "ln $< $@",
+          )

--- a/mediapipe/web/graph_runner/run_script_helper.ts.template
+++ b/mediapipe/web/graph_runner/run_script_helper.ts.template
@@ -10,7 +10,16 @@ declare function importScripts(...urls: Array<string|URL>): void;
 // Quick helper to run the given script safely
 export async function runScript(scriptUrl: string) {
   if (typeof importScripts === 'function') {
-    importScripts(scriptUrl.toString());
+     try {
+        importScripts(scriptUrl.toString());
+    } catch (error) { 
+        if (error instanceof TypeError) {
+          // importScripts does not work in module workers
+          const module = await import(scriptUrl.toString());
+        } else {
+          throw error
+        }
+    }
   } else {
     const script = document.createElement('script');
     (script as {src:string}).src = scriptUrl.toString();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "module": "commonjs",
+    "target": "es2018",
+    "module": "es2020",
     "lib": ["ES2021", "dom"],
     "declaration": true,
     "moduleResolution": "node",


### PR DESCRIPTION
When using the mediapipe in Javascript from a worker, the library does not work if the worker is loaded from a module. This patch set addresses the issues so that it also loads successfully in this environment.

Note that this is a first attempt that is far from being final. Since I had to change the compile options of the typescript compiler, the `import()` statement survives compilation. I think rollup and the commonJS plugin will nevertheless provide commonJS code. On the other hand, I also had to increase the JavaScript specification. It may be a better option not to run the code with the import statement through the TS compiler so as not to break compatibility with older JavaScript.

Furthermore, I had to patch the wasm import code. Adding the fix upstream to the code may be better than patching it here.