### PR TITLE
Added failure tests and test utils for  iOS AudioRecord

### DIFF
--- a/mediapipe/tasks/ios/audio/core/BUILD
+++ b/mediapipe/tasks/ios/audio/core/BUILD
@@ -21,9 +21,16 @@ objc_library(
     srcs = ["sources/MPPAudioData.m"],
     hdrs = ["sources/MPPAudioData.h"],
     deps = [
+        ":MPPAudioDataFormat",
         ":MPPFloatBuffer",
         ":MPPFloatRingBuffer",
     ],
+)
+
+objc_library(
+    name = "MPPAudioDataFormat",
+    srcs = ["sources/MPPAudioDataFormat.m"],
+    hdrs = ["sources/MPPAudioDataFormat.h"],
 )
 
 objc_library(
@@ -56,10 +63,11 @@ objc_library(
         "-std=c++17",
     ],
     deps = [
-        ":MPPAudioData",
+        ":MPPAudioDataFormat",
         ":MPPFloatBuffer",
         ":MPPFloatRingBuffer",
         "//mediapipe/tasks/ios/common:MPPCommon",
         "//mediapipe/tasks/ios/common/utils:MPPCommonUtils",
+        "//third_party/apple_frameworks:AVFoundation",
     ],
 )

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioData.h
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioData.h
@@ -13,49 +13,10 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h"
 #import "mediapipe/tasks/ios/audio/core/sources/MPPFloatBuffer.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-/**
- * Wraps properties describing the format of the incoming audio samples, namely number of channels
- * and the sample rate.
- */
-NS_SWIFT_NAME(AudioDataFormat)
-
-@interface MPPAudioDataFormat : NSObject
-
-/** Number of channels */
-@property(nonatomic, readonly) NSUInteger channelCount;
-
-/** Sample rate */
-@property(nonatomic, readonly) NSUInteger sampleRate;
-
-/**
- * Initializes a new `AudioDataFormat` with the given channel count and sample rate.
- *
- * @param channelCount Number of channels.
- * @param sampleRate Sample rate.
- *
- * @return A new instance of `AudioDataFormat` with the given channel count and sample rate.
- */
-- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate;
-
-/**
- * Initializes a new `AudioDataFormat` with the default channel count of 1 and the given sample
- * rate.
- *
- * @param sampleRate Sample rate.
- * @return A new instance of `AudioDataFormat` with the default channel count of 1 and the given
- * sample rate.
- */
-- (instancetype)initWithSampleRate:(NSUInteger)sampleRate;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-+ (instancetype)new NS_UNAVAILABLE;
-
-@end
 
 /**
  * A wrapper class for input audio samples used in on-device machine learning using MediaPipe Task

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioData.m
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioData.m
@@ -15,8 +15,6 @@
 #import "mediapipe/tasks/ios/audio/core/sources/MPPAudioData.h"
 #import "mediapipe/tasks/ios/audio/core/sources/MPPFloatRingBuffer.h"
 
-static const NSInteger kDefaultChannelCount = 1;
-
 @implementation MPPAudioData {
   MPPFloatRingBuffer *_ringBuffer;
 }
@@ -45,29 +43,6 @@ static const NSInteger kDefaultChannelCount = 1;
 
 - (NSUInteger)bufferLength {
   return _ringBuffer.length;
-}
-
-@end
-
-@implementation MPPAudioDataFormat
-
-- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate {
-  self = [super init];
-  if (self) {
-    _channelCount = channelCount;
-    _sampleRate = sampleRate;
-  }
-  return self;
-}
-
-- (instancetype)initWithSampleRate:(NSUInteger)sampleRate {
-  return [self initWithChannelCount:kDefaultChannelCount sampleRate:sampleRate];
-}
-
-- (BOOL)isEqual:(id)object {
-  return [object isKindOfClass:[self class]] &&
-         self.channelCount == [(MPPAudioDataFormat *)object channelCount] &&
-         self.sampleRate == [(MPPAudioDataFormat *)object sampleRate];
 }
 
 @end

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h
@@ -1,0 +1,59 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wraps properties describing the format of the incoming audio samples, namely number of channels
+ * and the sample rate.
+ */
+NS_SWIFT_NAME(AudioDataFormat)
+
+@interface MPPAudioDataFormat : NSObject
+
+/** Number of channels */
+@property(nonatomic, readonly) NSUInteger channelCount;
+
+/** Sample rate */
+@property(nonatomic, readonly) NSUInteger sampleRate;
+
+/**
+ * Initializes a new `AudioDataFormat` with the given channel count and sample rate.
+ *
+ * @param channelCount Number of channels.
+ * @param sampleRate Sample rate.
+ *
+ * @return A new instance of `AudioDataFormat` with the given channel count and sample rate.
+ */
+- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate;
+
+/**
+ * Initializes a new `AudioDataFormat` with the default channel count of 1 and the given sample
+ * rate.
+ *
+ * @param sampleRate Sample rate.
+ * @return A new instance of `AudioDataFormat` with the default channel count of 1 and the given
+ * sample rate.
+ */
+- (instancetype)initWithSampleRate:(NSUInteger)sampleRate;
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.m
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.m
@@ -1,0 +1,40 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h"
+
+static const NSInteger kDefaultChannelCount = 1;
+
+@implementation MPPAudioDataFormat
+
+- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate {
+  self = [super init];
+  if (self) {
+    _channelCount = channelCount;
+    _sampleRate = sampleRate;
+  }
+  return self;
+}
+
+- (instancetype)initWithSampleRate:(NSUInteger)sampleRate {
+  return [self initWithChannelCount:kDefaultChannelCount sampleRate:sampleRate];
+}
+
+- (BOOL)isEqual:(id)object {
+  return [object isKindOfClass:[self class]] &&
+         self.channelCount == [(MPPAudioDataFormat *)object channelCount] &&
+         self.sampleRate == [(MPPAudioDataFormat *)object sampleRate];
+}
+
+@end

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioRecord.h
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioRecord.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioData.h"
+#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h"
 #import "mediapipe/tasks/ios/audio/core/sources/MPPFloatBuffer.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioRecord.m
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioRecord.m
@@ -138,7 +138,6 @@ static const NSUInteger kMaximumChannelCount = 2;
   });
 }
 
-
 - (nullable MPPFloatBuffer *)readAtOffset:(NSUInteger)offset
                                withLength:(NSUInteger)length
                                     error:(NSError **)error {
@@ -242,15 +241,17 @@ static const NSUInteger kMaximumChannelCount = 2;
                 error:error];
 }
 
-- (void)convertAndLoadBuffer:(AVAudioPCMBuffer *)buffer
+- (BOOL)convertAndLoadBuffer:(AVAudioPCMBuffer *)buffer
          usingAudioConverter:(AVAudioConverter *)audioConverter
                        error:(NSError **)error {
   AVAudioPCMBuffer *convertedPCMBuffer = [MPPAudioRecord bufferFromInputBuffer:buffer
                                                            usingAudioConverter:audioConverter
                                                                          error:error];
   if (convertedPCMBuffer) {
-    [self loadAudioPCMBuffer:convertedPCMBuffer error:error];
+    return [self loadAudioPCMBuffer:convertedPCMBuffer error:error];
   }
+
+  return NO;
 }
 
 + (AVAudioPCMBuffer *)bufferFromInputBuffer:(AVAudioPCMBuffer *)pcmBuffer

--- a/mediapipe/tasks/ios/test/audio/core/BUILD
+++ b/mediapipe/tasks/ios/test/audio/core/BUILD
@@ -61,3 +61,33 @@ ios_unit_test(
         ":MPPFloatRingBufferObjcTestLibrary",
     ],
 )
+
+objc_library(
+    name = "MPPAudioRecordObjcTestLibrary",
+    testonly = 1,
+    srcs = ["MPPAudioRecordTests.mm"],
+    copts = [
+        "-ObjC++",
+        "-std=c++17",
+        "-x objective-c++",
+    ],
+    tags = TFL_DEFAULT_TAGS,
+    data = [
+        "//mediapipe/tasks/testdata/audio:test_audio_clips",
+    ],
+    deps = [
+        "//mediapipe/tasks/ios/audio/core:MPPAudioRecord",
+        "//mediapipe/tasks/ios/common:MPPCommon",
+        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
+    ],
+)
+
+ios_unit_test(
+    name = "MPPAudioRecordObjcTest",
+    minimum_os_version = MPP_TASK_MINIMUM_OS_VERSION,
+    runner = tflite_ios_lab_runner("IOS_LATEST"),
+    tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
+    deps = [
+        ":MPPAudioRecordObjcTestLibrary",
+    ],
+)

--- a/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
+++ b/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
@@ -19,10 +19,10 @@
 #import "mediapipe/tasks/ios/common/sources/MPPCommon.h"
 #import "mediapipe/tasks/ios/test/utils/sources/MPPFileInfo.h"
 
-static MPPFileInfo *const kSpeech16KHzMonoFileInfo = [[MPPFileInfo alloc] initWithName:@"speech_16000_hz_mono"
-                                                                            type:@"wav"];
-                                                                          
-static AVAudioFormat * kAudioEngineFormat =
+static MPPFileInfo *const kSpeech16KHzMonoFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"speech_16000_hz_mono" type:@"wav"];
+
+static AVAudioFormat *kAudioEngineFormat =
     [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
                                      sampleRate:48000
                                        channels:1
@@ -94,7 +94,9 @@ NS_ASSUME_NONNULL_BEGIN
   AssertEqualErrors(error, expectedError);
 }
 
-+ (MPPAudioRecord *)createAudioRecordWithChannelCount:(const NSInteger)channelCount sampleRate:(const NSInteger)sampleRate bufferLength:(const NSInteger)bufferLength {
++ (MPPAudioRecord *)createAudioRecordWithChannelCount:(const NSInteger)channelCount
+                                           sampleRate:(const NSInteger)sampleRate
+                                         bufferLength:(const NSInteger)bufferLength {
   MPPAudioDataFormat *audioDataFormat =
       [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
 
@@ -102,9 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                                    bufferLength:bufferLength
                                                                           error:nil];
 
-   XCTAssertNotNil(audioRecord);
+  XCTAssertNotNil(audioRecord);
 
-   return audioRecord;                                                                      
+  return audioRecord;
 }
 
 @end

--- a/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
+++ b/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
@@ -1,0 +1,112 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <AVFoundation/AVFoundation.h>
+#import <XCTest/XCTest.h>
+
+#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioRecord.h"
+#import "mediapipe/tasks/ios/common/sources/MPPCommon.h"
+#import "mediapipe/tasks/ios/test/utils/sources/MPPFileInfo.h"
+
+static MPPFileInfo *const kSpeech16KHzMonoFileInfo = [[MPPFileInfo alloc] initWithName:@"speech_16000_hz_mono"
+                                                                            type:@"wav"];
+                                                                          
+static AVAudioFormat * kAudioEngineFormat =
+    [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
+                                     sampleRate:48000
+                                       channels:1
+                                    interleaved:NO];
+
+static NSString *const kExpectedErrorDomain = @"com.google.mediapipe.tasks";
+
+#define AssertEqualErrors(error, expectedError)              \
+  XCTAssertNotNil(error);                                    \
+  XCTAssertEqualObjects(error.domain, expectedError.domain); \
+  XCTAssertEqual(error.code, expectedError.code);            \
+  XCTAssertEqualObjects(error.localizedDescription, expectedError.localizedDescription)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MPPAudioRecordTests : XCTestCase
+@end
+
+@implementation MPPAudioRecordTests
+
+- (void)testInitAudioRecordFailsWithInvalidChannelCount {
+  const NSInteger channelCount = 3;
+  const NSInteger sampleRate = 8000;
+  MPPAudioDataFormat *audioDataFormat =
+      [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
+
+  NSError *error = nil;
+  const NSInteger bufferLength = 100;
+  MPPAudioRecord *audioRecord = [[MPPAudioRecord alloc] initWithAudioDataFormat:audioDataFormat
+                                                                   bufferLength:100
+                                                                          error:&error];
+  XCTAssertNil(audioRecord);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey : @"The channel count provided does not match the "
+                                           @"supported channel count. Only channels counts "
+                                           @"in the range [1 : 2] are supported"
+             }];
+
+  AssertEqualErrors(error, expectedError);
+}
+
+- (void)testInitAudioRecordFailsWithInvalidBufferLength {
+  const NSInteger channelCount = 2;
+  const NSInteger sampleRate = 8000;
+  MPPAudioDataFormat *audioDataFormat =
+      [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
+
+  NSError *error = nil;
+  const NSInteger bufferLength = 101;
+  MPPAudioRecord *audioRecord = [[MPPAudioRecord alloc] initWithAudioDataFormat:audioDataFormat
+                                                                   bufferLength:bufferLength
+                                                                          error:&error];
+  XCTAssertNil(audioRecord);
+
+  NSError *expectedError =
+      [NSError errorWithDomain:kExpectedErrorDomain
+                          code:MPPTasksErrorCodeInvalidArgumentError
+                      userInfo:@{
+                        NSLocalizedDescriptionKey :
+                            [NSString stringWithFormat:@"The buffer length provided (%lu) is not a "
+                                                       @"multiple of channel count(%lu).",
+                                                       bufferLength, audioDataFormat.channelCount]
+                      }];
+
+  AssertEqualErrors(error, expectedError);
+}
+
++ (MPPAudioRecord *)createAudioRecordWithChannelCount:(const NSInteger)channelCount sampleRate:(const NSInteger)sampleRate bufferLength:(const NSInteger)bufferLength {
+  MPPAudioDataFormat *audioDataFormat =
+      [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
+
+  MPPAudioRecord *audioRecord = [[MPPAudioRecord alloc] initWithAudioDataFormat:audioDataFormat
+                                                                   bufferLength:bufferLength
+                                                                          error:nil];
+
+   XCTAssertNotNil(audioRecord);
+
+   return audioRecord;                                                                      
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/test/audio/core/utils/BUILD
+++ b/mediapipe/tasks/ios/test/audio/core/utils/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2024 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//mediapipe/tasks:internal"])
+
+licenses(["notice"])
+
+objc_library(
+    name = "AVAudioPCMBufferTestUtils",
+    srcs = ["sources/AVAudioPCMBuffer+TestUtils.m",],
+    hdrs = ["sources/AVAudioPCMBuffer+TestUtils.h",],
+    deps = [
+        "//mediapipe/tasks/ios/audio/core:MPPAudioDataFormat",
+        "//mediapipe/tasks/ios/audio/core:MPPFloatBuffer",
+        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
+    ],
+)

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h
@@ -1,0 +1,56 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <AVFoundation/AVFoundation.h>
+#import <Foundation/Foundation.h>
+#import "mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h"
+#import "mediapipe/tasks/ios/audio/core/sources/MPPFloatBuffer.h"
+#import "mediapipe/tasks/ios/test/utils/sources/MPPFileInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Utils for operations on `AVAudioPCMBuffer` needed for tests.
+ */
+@interface AVAudioPCMBuffer (TestUtils)
+
+@property(nonatomic, readonly, nullable) MPPFloatBuffer *floatBuffer;
+
+/**
+ * Creates an `AVAudioPCMBuffer` from the file specified by `fileInfo`. If the format of the audio
+ * file is equal to the processing format, the samples loaded from the file are directly returned.
+ * If not, the pcm buffer is converted to the processing format.
+ * 
+ * @param fileInfo `FileInfo` with name and type of the audio file stored in the bundle.
+ * @param fileInfo The `AVAudioFormat` to which the audio samples are to be converted.
+ * 
+ * @return Newly created audio pcm buffer satisfying the processing format. `nil` if there was an
+ * error during conversion.
+ */
+- (nullable AVAudioPCMBuffer *)initFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
+                                        processingFormat:(AVAudioFormat *)processingFormat;
+
+/**
+ * Converts the current pcm buffer to a pcm buffer using the specified audio converter
+ *
+ * @param audioConverter The audio converter to use for conversion.
+ *
+ * @return Newly created audio pcm buffer satisfying the processing format. `nil` if there was an
+ * error during conversion.
+ */
+- (nullable AVAudioPCMBuffer *)bufferUsingAudioConverter:(AVAudioConverter *)audioConverter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h
@@ -31,15 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
  * Creates an `AVAudioPCMBuffer` from the file specified by `fileInfo`. If the format of the audio
  * file is equal to the processing format, the samples loaded from the file are directly returned.
  * If not, the pcm buffer is converted to the processing format.
- * 
+ *
  * @param fileInfo `FileInfo` with name and type of the audio file stored in the bundle.
  * @param fileInfo The `AVAudioFormat` to which the audio samples are to be converted.
- * 
+ *
  * @return Newly created audio pcm buffer satisfying the processing format. `nil` if there was an
  * error during conversion.
  */
-- (nullable AVAudioPCMBuffer *)initFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
-                                        processingFormat:(AVAudioFormat *)processingFormat;
++ (nullable AVAudioPCMBuffer *)bufferFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
+                                          processingFormat:(AVAudioFormat *)processingFormat;
 
 /**
  * Converts the current pcm buffer to a pcm buffer using the specified audio converter

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.m
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.m
@@ -16,8 +16,8 @@
 
 @implementation AVAudioPCMBuffer (TestUtils)
 
-- (nullable AVAudioPCMBuffer *)initFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
-                                        processingFormat:(AVAudioFormat *)processingFormat {
++ (nullable AVAudioPCMBuffer *)bufferFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
+                                          processingFormat:(AVAudioFormat *)processingFormat {
   AVAudioFile *audioFile = [[AVAudioFile alloc] initForReading:[NSURL fileURLWithPath:fileInfo.path]
                                                          error:nil];
   AVAudioPCMBuffer *buffer =

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.m
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.m
@@ -1,0 +1,88 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h"
+
+@implementation AVAudioPCMBuffer (TestUtils)
+
+- (nullable AVAudioPCMBuffer *)initFromAudioFileWithInfo:(MPPFileInfo *)fileInfo
+                                        processingFormat:(AVAudioFormat *)processingFormat {
+  AVAudioFile *audioFile = [[AVAudioFile alloc] initForReading:[NSURL fileURLWithPath:fileInfo.path]
+                                                         error:nil];
+  AVAudioPCMBuffer *buffer =
+      [[AVAudioPCMBuffer alloc] initWithPCMFormat:audioFile.processingFormat
+                                    frameCapacity:(AVAudioFrameCount)audioFile.length];
+
+  [audioFile readIntoBuffer:buffer error:nil];
+
+  return [buffer bufferWithProcessingFormat:processingFormat];
+}
+
+- (nullable MPPFloatBuffer *)floatBuffer {
+  if (self.format.commonFormat != AVAudioPCMFormatFloat32) {
+    return nil;
+  }
+
+  return [[MPPFloatBuffer alloc] initWithData:self.floatChannelData[0] length:self.frameLength];
+}
+
+- (AVAudioPCMBuffer *)bufferWithProcessingFormat:(AVAudioFormat *)processingFormat {
+  if ([self.format isEqual:processingFormat]) {
+    return self;
+  }
+
+  AVAudioConverter *audioConverter = [[AVAudioConverter alloc] initFromFormat:self.format
+                                                                     toFormat:processingFormat];
+
+  return [self bufferUsingAudioConverter:audioConverter];
+}
+
+- (AVAudioPCMBuffer *)bufferUsingAudioConverter:(AVAudioConverter *)audioConverter {
+  if (!audioConverter) {
+    return nil;
+  }
+  // Capacity of converted PCM buffer is calculated in order to maintain the same
+  // latency as the input pcmBuffer.
+  AVAudioFrameCount capacity = ceil(self.frameLength * audioConverter.outputFormat.sampleRate /
+                                    audioConverter.inputFormat.sampleRate);
+  AVAudioPCMBuffer *outPCMBuffer = [[AVAudioPCMBuffer alloc]
+      initWithPCMFormat:audioConverter.outputFormat
+          frameCapacity:capacity * (AVAudioFrameCount)audioConverter.outputFormat.channelCount];
+
+  AVAudioConverterInputBlock inputBlock = ^AVAudioBuffer *_Nullable(
+      AVAudioPacketCount inNumberOfPackets, AVAudioConverterInputStatus *_Nonnull outStatus) {
+    *outStatus = AVAudioConverterInputStatus_HaveData;
+    return self;
+  };
+
+  AVAudioConverterOutputStatus converterStatus = [audioConverter convertToBuffer:outPCMBuffer
+                                                                           error:nil
+                                                              withInputFromBlock:inputBlock];
+  switch (converterStatus) {
+    case AVAudioConverterOutputStatus_HaveData: {
+      return outPCMBuffer;
+    }
+    case AVAudioConverterOutputStatus_InputRanDry:
+    case AVAudioConverterOutputStatus_EndOfStream:
+    case AVAudioConverterOutputStatus_Error: {
+      // Conversion failed so returning a nil. Reason of the error isn't
+      // important for tests.
+      break;
+    }
+  }
+
+  return nil;
+}
+
+@end


### PR DESCRIPTION
1. Added couple of failure tests for iOS AudioRecord
2. Added tests utils for AudioRecord.
3. Moved MPPAudioDataFormat to a new file.