### PR TITLE
Fixed typo in word 'timetamp' & 'Timetamps'

### DIFF
--- a/mediapipe/framework/calculator_graph_bounds_test.cc
+++ b/mediapipe/framework/calculator_graph_bounds_test.cc
@@ -804,10 +804,10 @@ TEST(CalculatorGraphBoundsTest, BoundWithoutInputPackets) {
 }
 
 // Shows that when fixed-size-input-stream-handler drops packets,
-// no timetamp bounds are announced.
+// no timestamp bounds are announced.
 TEST(CalculatorGraphBoundsTest, FixedSizeHandlerBounds) {
   // LambdaCalculator with FixedSizeInputStreamHandler will drop packets
-  // while it is busy.  Timetamps for the dropped packets are only relevant
+  // while it is busy.  Timestamps for the dropped packets are only relevant
   // when SetOffset is active on the LambdaCalculator.
   // The PassthroughCalculator delivers an output packet whenever the
   // LambdaCalculator delivers a timestamp bound.

--- a/mediapipe/framework/calculator_profile.proto
+++ b/mediapipe/framework/calculator_profile.proto
@@ -102,7 +102,7 @@ message GraphTrace {
     // The time at which the packet exited the stream.
     optional int64 finish_time = 2;
 
-    // The identifying timetamp of the packet.
+    // The identifying timestamp of the packet.
     optional int64 packet_timestamp = 3;
 
     // The index of the stream in the stream_name list.
@@ -160,7 +160,7 @@ message GraphTrace {
     // The timing data for each input packet.
     repeated StreamTrace input_trace = 6;
 
-    // The identifying timetamp and stream_id for each output packet.
+    // The identifying timestamp and stream_id for each output packet.
     repeated StreamTrace output_trace = 7;
 
     // An identifier for the current process thread.

--- a/mediapipe/framework/profiler/trace_builder.cc
+++ b/mediapipe/framework/profiler/trace_builder.cc
@@ -293,7 +293,7 @@ class TraceBuilder::Impl {
     }
   }
 
-  // Return a timestamp in micros relative to the base timetamp.
+  // Return a timestamp in micros relative to the base timestamp.
   int64_t LogTimestamp(Timestamp ts) { return ts.Value() - base_ts_; }
 
   // Return a time in micros relative to the base time.

--- a/mediapipe/java/com/google/mediapipe/components/ExternalTextureConverter.java
+++ b/mediapipe/java/com/google/mediapipe/components/ExternalTextureConverter.java
@@ -185,7 +185,7 @@ public class ExternalTextureConverter implements TextureFrameProducer {
   /**
    * Sets an offset that can be used to adjust the timestamps on the camera frames, for example to
    * conform to a preferred time-base or to account for a known device latency. The offset is added
-   * to each frame timetamp read by the ExternalTextureConverter.
+   * to each frame timestamp read by the ExternalTextureConverter.
    */
   public void setTimestampOffsetNanos(long offsetInNanos) {
     thread.setTimestampOffsetNanos(offsetInNanos);


### PR DESCRIPTION
While using this code, I encountered a typo in the files :
`mediapipe/framework/calculator_graph_bounds_test.cc`
`mediapipe/framework/calculator_profile.proto`
`mediapipe/framework/profiler/trace_builder.cc`
`mediapipe/java/com/google/mediapipe/components/ExternalTextureConverter.java`

The word `'timetamp'` was incorrectly used instead of `'timestamp'`. I have corrected this typo and opened a pull request referencing the corresponding issue number.