### PR TITLE
Remove preprocessor directives in function-like macros.

### DIFF
--- a/mediapipe/tasks/cc/core/task_api_factory.h
+++ b/mediapipe/tasks/cc/core/task_api_factory.h
@@ -76,15 +76,17 @@ class TaskApiFactory {
         found_task_subgraph = true;
       }
     }
+#if !MEDIAPIPE_DISABLE_GPU
     MP_ASSIGN_OR_RETURN(
         auto runner,
-#if !MEDIAPIPE_DISABLE_GPU
         core::TaskRunner::Create(std::move(graph_config), std::move(resolver),
                                  std::move(packets_callback),
                                  std::move(default_executor),
                                  std::move(input_side_packets),
                                  /*resources=*/nullptr, std::move(error_fn)));
 #else
+    MP_ASSIGN_OR_RETURN(
+        auto runner,
         core::TaskRunner::Create(
             std::move(graph_config), std::move(resolver),
             std::move(packets_callback), std::move(default_executor),


### PR DESCRIPTION
This PR fixes issue #5366 by reworking the preprocessor directives to surround the function-like macro rather than occurring inside the function-like macro parameter list.

This change allows the GDMP project to successfully build its windows target rather than failing with:
`.\mediapipe/tasks/cc/core/task_api_factory.h(86): error C2121: '#': invalid character: possibly the result of a macro expansion`
